### PR TITLE
Made m_wrapper public to be able to compile artery

### DIFF
--- a/vanetza/asn1/asn1c_conversion.hpp
+++ b/vanetza/asn1/asn1c_conversion.hpp
@@ -47,13 +47,14 @@ public:
         return m_wrapper;
     }
 
+    std::shared_ptr<wrapper_type> m_wrapper;
+
 private:
     byte_buffer_impl(const std::shared_ptr<wrapper_type>& other) :
         m_wrapper(other)
     {
     }
 
-    std::shared_ptr<wrapper_type> m_wrapper;
 };
 
 } // namespace convertible


### PR DESCRIPTION
gcc 5.3.1 failed compilation due to m_wrapper being private