### PR TITLE
Allow usage of GPSD faker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+build
 conanfile.pyc
 doc

--- a/tools/socktap/CMakeLists.txt
+++ b/tools/socktap/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(GPS REQUIRED)
 
 add_executable(socktap
     application.cpp
+    dcc_passthrough.cpp
     ethernet_device.cpp
     gps_position_provider.cpp
     hello_application.cpp

--- a/tools/socktap/dcc_passthrough.cpp
+++ b/tools/socktap/dcc_passthrough.cpp
@@ -1,3 +1,4 @@
+#include "dcc_passthrough.hpp"
 #include "time_trigger.hpp"
 #include <vanetza/dcc/data_request.hpp>
 #include <vanetza/dcc/interface.hpp>
@@ -10,49 +11,39 @@ namespace asio = boost::asio;
 using boost::asio::generic::raw_protocol;
 using namespace vanetza;
 
-class DccPassthrough : public dcc::RequestInterface
-{
-public:
-    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger) :
+DccPassthrough::DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger) :
         socket_(socket), trigger_(trigger) {}
 
-    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet)
-    {
-        if (!allow_packet_flow_) {
-            std::cout << "ignored request because packet flow is suppressed\n";
-            return;
-        }
 
-        buffers_[0] = create_ethernet_header(request.destination, request.source, request.ether_type);
-        for (auto& layer : osi_layer_range<OsiLayer::Network, OsiLayer::Application>()) {
-            const auto index = distance(OsiLayer::Link, layer);
-            packet->layer(layer).convert(buffers_[index]);
-        }
-
-        trigger_.schedule();
-
-        std::array<asio::const_buffer, layers_> const_buffers;
-        for (unsigned i = 0; i < const_buffers.size(); ++i) {
-            const_buffers[i] = asio::buffer(buffers_[i]);
-        }
-        auto bytes_sent = socket_.send(const_buffers);
-        std::cout << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
+void DccPassthrough::request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet)
+{
+    if (!allow_packet_flow_) {
+        std::cout << "ignored request because packet flow is suppressed\n";
+        return;
     }
 
-    void allow_packet_flow(bool allow)
-    {
-        allow_packet_flow_ = allow;
+    buffers_[0] = create_ethernet_header(request.destination, request.source, request.ether_type);
+    for (auto& layer : osi_layer_range<OsiLayer::Network, OsiLayer::Application>()) {
+        const auto index = distance(OsiLayer::Link, layer);
+        packet->layer(layer).convert(buffers_[index]);
     }
 
-    bool allow_packet_flow()
-    {
-        return allow_packet_flow_;
-    }
+    trigger_.schedule();
 
-private:
-    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
-    raw_protocol::socket& socket_;
-    std::array<ByteBuffer, layers_> buffers_;
-    TimeTrigger& trigger_;
-    bool allow_packet_flow_ = true;
-};
+    std::array<asio::const_buffer, layers_> const_buffers;
+    for (unsigned i = 0; i < const_buffers.size(); ++i) {
+        const_buffers[i] = asio::buffer(buffers_[i]);
+    }
+    auto bytes_sent = socket_.send(const_buffers);
+    std::cout << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
+}
+
+void DccPassthrough::allow_packet_flow(bool allow)
+{
+    allow_packet_flow_ = allow;
+}
+
+bool DccPassthrough::allow_packet_flow()
+{
+    return allow_packet_flow_;
+}

--- a/tools/socktap/dcc_passthrough.cpp
+++ b/tools/socktap/dcc_passthrough.cpp
@@ -1,0 +1,58 @@
+#include "time_trigger.hpp"
+#include <vanetza/dcc/data_request.hpp>
+#include <vanetza/dcc/interface.hpp>
+#include <vanetza/net/ethernet_header.hpp>
+#include <vanetza/net/chunk_packet.hpp>
+#include <boost/asio/generic/raw_protocol.hpp>
+#include <iostream>
+
+namespace asio = boost::asio;
+using boost::asio::generic::raw_protocol;
+using namespace vanetza;
+
+class DccPassthrough : public dcc::RequestInterface
+{
+public:
+    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger) :
+        socket_(socket), trigger_(trigger) {}
+
+    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet)
+    {
+        if (!allow_packet_flow_) {
+            std::cout << "ignored request because packet flow is suppressed\n";
+            return;
+        }
+
+        buffers_[0] = create_ethernet_header(request.destination, request.source, request.ether_type);
+        for (auto& layer : osi_layer_range<OsiLayer::Network, OsiLayer::Application>()) {
+            const auto index = distance(OsiLayer::Link, layer);
+            packet->layer(layer).convert(buffers_[index]);
+        }
+
+        trigger_.schedule();
+
+        std::array<asio::const_buffer, layers_> const_buffers;
+        for (unsigned i = 0; i < const_buffers.size(); ++i) {
+            const_buffers[i] = asio::buffer(buffers_[i]);
+        }
+        auto bytes_sent = socket_.send(const_buffers);
+        std::cout << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
+    }
+
+    void allow_packet_flow(bool allow)
+    {
+        allow_packet_flow_ = allow;
+    }
+
+    bool allow_packet_flow()
+    {
+        return allow_packet_flow_;
+    }
+
+private:
+    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
+    raw_protocol::socket& socket_;
+    std::array<ByteBuffer, layers_> buffers_;
+    TimeTrigger& trigger_;
+    bool allow_packet_flow_ = true;
+};

--- a/tools/socktap/dcc_passthrough.hpp
+++ b/tools/socktap/dcc_passthrough.hpp
@@ -1,0 +1,35 @@
+#ifndef DCC_PASSTHROUGH_HPP_GSDFESAE
+#define DCC_PASSTHROUGH_HPP_GSDFESAE
+
+#include "time_trigger.hpp"
+#include <vanetza/dcc/data_request.hpp>
+#include <vanetza/dcc/interface.hpp>
+#include <vanetza/net/ethernet_header.hpp>
+#include <vanetza/net/cohesive_packet.hpp>
+#include <boost/asio/generic/raw_protocol.hpp>
+#include <iostream>
+
+namespace asio = boost::asio;
+using boost::asio::generic::raw_protocol;
+using namespace vanetza;
+
+class DccPassthrough : public dcc::RequestInterface
+{
+public:
+    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger);
+
+    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet);
+
+    void allow_packet_flow(bool allow);
+
+    bool allow_packet_flow();
+
+private:
+    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
+    raw_protocol::socket& socket_;
+    std::array<ByteBuffer, layers_> buffers_;
+    TimeTrigger& trigger_;
+    bool allow_packet_flow_ = true;
+};
+
+#endif /* DCC_PASSTHROUGH_HPP_GSDFESAE */

--- a/tools/socktap/dcc_passthrough.hpp
+++ b/tools/socktap/dcc_passthrough.hpp
@@ -9,25 +9,21 @@
 #include <boost/asio/generic/raw_protocol.hpp>
 #include <iostream>
 
-namespace asio = boost::asio;
-using boost::asio::generic::raw_protocol;
-using namespace vanetza;
-
-class DccPassthrough : public dcc::RequestInterface
+class DccPassthrough : public vanetza::dcc::RequestInterface
 {
 public:
-    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger);
+    DccPassthrough(boost::asio::generic::raw_protocol::socket& socket, TimeTrigger& trigger);
 
-    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet);
+    void request(const vanetza::dcc::DataRequest& request, std::unique_ptr<vanetza::ChunkPacket> packet);
 
     void allow_packet_flow(bool allow);
 
     bool allow_packet_flow();
 
 private:
-    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
-    raw_protocol::socket& socket_;
-    std::array<ByteBuffer, layers_> buffers_;
+    static constexpr std::size_t layers_ = num_osi_layers(vanetza::OsiLayer::Link, vanetza::OsiLayer::Application);
+    boost::asio::generic::raw_protocol::socket& socket_;
+    std::array<vanetza::ByteBuffer, layers_> buffers_;
     TimeTrigger& trigger_;
     bool allow_packet_flow_ = true;
 };

--- a/tools/socktap/gps_position_provider.cpp
+++ b/tools/socktap/gps_position_provider.cpp
@@ -7,7 +7,7 @@ static_assert(GPSD_API_MAJOR_VERSION == 6, "libgps has incompatible API");
 
 GpsPositionProvider::GpsPositionProvider()
 {
-    if (gps_open(GPSD_SHARED_MEMORY, nullptr, &gps_data)) {
+    if (gps_open("127.0.0.1", "2947", &gps_data)) {
         throw gps_error(errno);
     }
     gps_stream(&gps_data, WATCH_ENABLE | WATCH_JSON, nullptr);

--- a/tools/socktap/router_context.cpp
+++ b/tools/socktap/router_context.cpp
@@ -1,4 +1,5 @@
 #include "application.hpp"
+#include "dcc_passthrough.hpp"
 #include "ethernet_device.hpp"
 #include "position_provider.hpp"
 #include "router_context.hpp"
@@ -13,41 +14,11 @@ namespace asio = boost::asio;
 using boost::asio::generic::raw_protocol;
 using namespace vanetza;
 
-class DccPassthrough : public dcc::RequestInterface
-{
-public:
-    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger) :
-        socket_(socket), trigger_(trigger) {}
-
-    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet)
-    {
-        buffers_[0] = create_ethernet_header(request.destination, request.source, request.ether_type);
-        for (auto& layer : osi_layer_range<OsiLayer::Network, OsiLayer::Application>()) {
-            const auto index = distance(OsiLayer::Link, layer);
-            packet->layer(layer).convert(buffers_[index]);
-        }
-
-        trigger_.schedule();
-
-        std::array<asio::const_buffer, layers_> const_buffers;
-        for (unsigned i = 0; i < const_buffers.size(); ++i) {
-            const_buffers[i] = asio::buffer(buffers_[i]);
-        }
-        auto bytes_sent = socket_.send(const_buffers);
-        std::cout << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
-    }
-
-private:
-    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
-    raw_protocol::socket& socket_;
-    std::array<ByteBuffer, layers_> buffers_;
-    TimeTrigger& trigger_;
-};
-
 geonet::MIB configure_mib(const EthernetDevice& device)
 {
     geonet::MIB mib;
     mib.itsGnLocalGnAddr.mid(device.address());
+    mib.itsGnLocalGnAddr.is_manually_configured(true);
     mib.itsGnLocalAddrConfMethod = geonet::AddrConfMethod::MANAGED;
     mib.itsGnSecurity = false;
     return mib;
@@ -123,9 +94,14 @@ void RouterContext::enable(Application* app)
 
 void RouterContext::update_position_vector()
 {
-    router_.update(positioning_.current_position());
+    auto position = positioning_.current_position();
+
+    router_.update(position);
     vanetza::Runtime::Callback callback = [this](vanetza::Clock::time_point) { this->update_position_vector(); };
     vanetza::Clock::duration next = std::chrono::seconds(1);
     trigger_.runtime().schedule(next, callback);
     trigger_.schedule();
+
+    // Skip all requests until a valid GPS position is available
+    request_interface_.get()->allow_packet_flow(position.position_accuracy_indicator);
 }

--- a/tools/socktap/router_context.hpp
+++ b/tools/socktap/router_context.hpp
@@ -1,6 +1,7 @@
 #ifndef ROUTER_CONTEXT_HPP_KIPUYBY2
 #define ROUTER_CONTEXT_HPP_KIPUYBY2
 
+#include "dcc_passthrough.hpp"
 #include <vanetza/btp/port_dispatcher.hpp>
 #include <vanetza/geonet/mib.hpp>
 #include <vanetza/geonet/router.hpp>
@@ -37,11 +38,10 @@ private:
     TimeTrigger& trigger_;
     PositionProvider& positioning_;
     vanetza::btp::PortDispatcher dispatcher_;
-    std::unique_ptr<vanetza::dcc::RequestInterface> request_interface_;
+    std::unique_ptr<DccPassthrough> request_interface_;
     vanetza::ByteBuffer receive_buffer_;
     boost::asio::generic::raw_protocol::endpoint receive_endpoint_;
     std::list<Application*> applications_;
 };
 
 #endif /* ROUTER_CONTEXT_HPP_KIPUYBY2 */
-


### PR DESCRIPTION
I currently use https://github.com/loewexy/gpsd-fake and commented out the same address check to send and receive messages on the local loopback inteface `lo`.

https://github.com/riebl/vanetza/blob/7548565d39d76bc8a5015d029edc5cf83c94e101/vanetza/geonet/router.cpp#L873

The above check fails if packets aren't skipped as long as a valid GPS position isn't available yet.