### PR TITLE
Add runtime options to socktap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+build
 conanfile.pyc
 doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Mandatory and optional project dependencies
 set(Boost_COMPONENTS date_time serialization)
-set(Boost_OPTIONAL_COMPONENTS system)
+set(Boost_OPTIONAL_COMPONENTS system program_options)
 find_package(Boost 1.58 REQUIRED
   COMPONENTS ${Boost_COMPONENTS}
   OPTIONAL_COMPONENTS ${Boost_OPTIONAL_COMPONENTS})
@@ -109,4 +109,3 @@ file(COPY ${CMAKECONFIG_BUILD_DIR}/VanetzaConfigVersion.cmake
 configure_file(cmake/VanetzaExportsConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/VanetzaConfig.cmake @ONLY)
 export(PACKAGE ${PROJECT_NAME})
-

--- a/tools/socktap/CMakeLists.txt
+++ b/tools/socktap/CMakeLists.txt
@@ -3,6 +3,11 @@ if(NOT TARGET Boost::system)
     return()
 endif()
 
+if(NOT TARGET Boost::program_options)
+    message(STATUS "Skip build of socktap because of missing Boost::program_options dependency")
+    return()
+endif()
+
 find_package(Threads REQUIRED)
 find_package(GPS REQUIRED)
 
@@ -10,10 +15,11 @@ add_executable(socktap
     application.cpp
     dcc_passthrough.cpp
     ethernet_device.cpp
+    fake_network_device.cpp
     gps_position_provider.cpp
     hello_application.cpp
     main.cpp
     router_context.cpp
     time_trigger.cpp
 )
-target_link_libraries(socktap Boost::system Threads::Threads GPS::GPS vanetza)
+target_link_libraries(socktap Boost::system Boost::program_options Threads::Threads GPS::GPS vanetza)

--- a/tools/socktap/CMakeLists.txt
+++ b/tools/socktap/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(GPS REQUIRED)
 
 add_executable(socktap
     application.cpp
+    dcc_passthrough.cpp
     ethernet_device.cpp
     gps_position_provider.cpp
     hello_application.cpp

--- a/tools/socktap/dcc_passthrough.cpp
+++ b/tools/socktap/dcc_passthrough.cpp
@@ -1,3 +1,4 @@
+#include "dcc_passthrough.hpp"
 #include "time_trigger.hpp"
 #include <vanetza/dcc/data_request.hpp>
 #include <vanetza/dcc/interface.hpp>
@@ -10,49 +11,39 @@ namespace asio = boost::asio;
 using boost::asio::generic::raw_protocol;
 using namespace vanetza;
 
-class DccPassthrough : public dcc::RequestInterface
-{
-public:
-    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger) :
+DccPassthrough::DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger) :
         socket_(socket), trigger_(trigger) {}
 
-    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet)
-    {
-        if (!allow_packet_flow_) {
-            std::cout << "ignored request because packet flow is suppressed\n";
-            return;
-        }
 
-        buffers_[0] = create_ethernet_header(request.destination, request.source, request.ether_type);
-        for (auto& layer : osi_layer_range<OsiLayer::Network, OsiLayer::Application>()) {
-            const auto index = distance(OsiLayer::Link, layer);
-            packet->layer(layer).convert(buffers_[index]);
-        }
-
-        trigger_.schedule();
-
-        std::array<asio::const_buffer, layers_> const_buffers;
-        for (unsigned i = 0; i < const_buffers.size(); ++i) {
-            const_buffers[i] = asio::buffer(buffers_[i]);
-        }
-        auto bytes_sent = socket_.send(const_buffers);
-        std::cout << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
+void DccPassthrough::request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet)
+{
+    if (!allow_packet_flow_) {
+        std::cout << "ignored request because packet flow is suppressed\n";
+        return;
     }
 
-    void allow_packet_flow(bool allow)
-    {
-        allow_packet_flow_ = allow;
+    buffers_[0] = create_ethernet_header(request.destination, request.source, request.ether_type);
+    for (auto& layer : osi_layer_range<OsiLayer::Network, OsiLayer::Application>()) {
+        const auto index = distance(OsiLayer::Link, layer);
+        packet->layer(layer).convert(buffers_[index]);
     }
 
-    bool allow_packet_flow()
-    {
-        return allow_packet_flow_;
-    }
+    trigger_.schedule();
 
-private:
-    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
-    raw_protocol::socket& socket_;
-    std::array<ByteBuffer, layers_> buffers_;
-    TimeTrigger& trigger_;
-    bool allow_packet_flow_ = true;
-};
+    std::array<asio::const_buffer, layers_> const_buffers;
+    for (unsigned i = 0; i < const_buffers.size(); ++i) {
+        const_buffers[i] = asio::buffer(buffers_[i]);
+    }
+    auto bytes_sent = socket_.send(const_buffers);
+    std::cout << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
+}
+
+void DccPassthrough::allow_packet_flow(bool allow)
+{
+    allow_packet_flow_ = allow;
+}
+
+bool DccPassthrough::allow_packet_flow()
+{
+    return allow_packet_flow_;
+}

--- a/tools/socktap/dcc_passthrough.cpp
+++ b/tools/socktap/dcc_passthrough.cpp
@@ -1,0 +1,58 @@
+#include "time_trigger.hpp"
+#include <vanetza/dcc/data_request.hpp>
+#include <vanetza/dcc/interface.hpp>
+#include <vanetza/net/ethernet_header.hpp>
+#include <vanetza/net/chunk_packet.hpp>
+#include <boost/asio/generic/raw_protocol.hpp>
+#include <iostream>
+
+namespace asio = boost::asio;
+using boost::asio::generic::raw_protocol;
+using namespace vanetza;
+
+class DccPassthrough : public dcc::RequestInterface
+{
+public:
+    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger) :
+        socket_(socket), trigger_(trigger) {}
+
+    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet)
+    {
+        if (!allow_packet_flow_) {
+            std::cout << "ignored request because packet flow is suppressed\n";
+            return;
+        }
+
+        buffers_[0] = create_ethernet_header(request.destination, request.source, request.ether_type);
+        for (auto& layer : osi_layer_range<OsiLayer::Network, OsiLayer::Application>()) {
+            const auto index = distance(OsiLayer::Link, layer);
+            packet->layer(layer).convert(buffers_[index]);
+        }
+
+        trigger_.schedule();
+
+        std::array<asio::const_buffer, layers_> const_buffers;
+        for (unsigned i = 0; i < const_buffers.size(); ++i) {
+            const_buffers[i] = asio::buffer(buffers_[i]);
+        }
+        auto bytes_sent = socket_.send(const_buffers);
+        std::cout << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
+    }
+
+    void allow_packet_flow(bool allow)
+    {
+        allow_packet_flow_ = allow;
+    }
+
+    bool allow_packet_flow()
+    {
+        return allow_packet_flow_;
+    }
+
+private:
+    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
+    raw_protocol::socket& socket_;
+    std::array<ByteBuffer, layers_> buffers_;
+    TimeTrigger& trigger_;
+    bool allow_packet_flow_ = true;
+};

--- a/tools/socktap/dcc_passthrough.hpp
+++ b/tools/socktap/dcc_passthrough.hpp
@@ -1,0 +1,35 @@
+#ifndef DCC_PASSTHROUGH_HPP_GSDFESAE
+#define DCC_PASSTHROUGH_HPP_GSDFESAE
+
+#include "time_trigger.hpp"
+#include <vanetza/dcc/data_request.hpp>
+#include <vanetza/dcc/interface.hpp>
+#include <vanetza/net/ethernet_header.hpp>
+#include <vanetza/net/cohesive_packet.hpp>
+#include <boost/asio/generic/raw_protocol.hpp>
+#include <iostream>
+
+namespace asio = boost::asio;
+using boost::asio::generic::raw_protocol;
+using namespace vanetza;
+
+class DccPassthrough : public dcc::RequestInterface
+{
+public:
+    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger);
+
+    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet);
+
+    void allow_packet_flow(bool allow);
+
+    bool allow_packet_flow();
+
+private:
+    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
+    raw_protocol::socket& socket_;
+    std::array<ByteBuffer, layers_> buffers_;
+    TimeTrigger& trigger_;
+    bool allow_packet_flow_ = true;
+};
+
+#endif /* DCC_PASSTHROUGH_HPP_GSDFESAE */

--- a/tools/socktap/dcc_passthrough.hpp
+++ b/tools/socktap/dcc_passthrough.hpp
@@ -9,25 +9,21 @@
 #include <boost/asio/generic/raw_protocol.hpp>
 #include <iostream>
 
-namespace asio = boost::asio;
-using boost::asio::generic::raw_protocol;
-using namespace vanetza;
-
-class DccPassthrough : public dcc::RequestInterface
+class DccPassthrough : public vanetza::dcc::RequestInterface
 {
 public:
-    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger);
+    DccPassthrough(boost::asio::generic::raw_protocol::socket& socket, TimeTrigger& trigger);
 
-    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet);
+    void request(const vanetza::dcc::DataRequest& request, std::unique_ptr<vanetza::ChunkPacket> packet);
 
     void allow_packet_flow(bool allow);
 
     bool allow_packet_flow();
 
 private:
-    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
-    raw_protocol::socket& socket_;
-    std::array<ByteBuffer, layers_> buffers_;
+    static constexpr std::size_t layers_ = num_osi_layers(vanetza::OsiLayer::Link, vanetza::OsiLayer::Application);
+    boost::asio::generic::raw_protocol::socket& socket_;
+    std::array<vanetza::ByteBuffer, layers_> buffers_;
     TimeTrigger& trigger_;
     bool allow_packet_flow_ = true;
 };

--- a/tools/socktap/ethernet_device.cpp
+++ b/tools/socktap/ethernet_device.cpp
@@ -6,6 +6,8 @@
 #include <net/if.h>
 #include <sys/ioctl.h>
 
+using boost::asio::generic::raw_protocol;
+
 void initialize(ifreq& request, const char* interface_name)
 {
     std::memset(&request, 0, sizeof(ifreq));
@@ -28,7 +30,7 @@ EthernetDevice::~EthernetDevice()
         ::close(local_socket_);
 }
 
-EthernetDevice::protocol::endpoint EthernetDevice::endpoint(int family) const
+raw_protocol::endpoint EthernetDevice::endpoint(int family) const
 {
     sockaddr_ll socket_address = {0};
     socket_address.sll_family = family;
@@ -46,11 +48,13 @@ int EthernetDevice::index() const
 
 vanetza::MacAddress EthernetDevice::address() const
 {
+    vanetza::MacAddress addr;
+
     ifreq data;
     initialize(data, interface_name_.c_str());
     ::ioctl(local_socket_, SIOCGIFHWADDR, &data);
 
-    vanetza::MacAddress addr;
     std::copy_n(data.ifr_hwaddr.sa_data, addr.octets.size(), addr.octets.data());
+
     return addr;
 }

--- a/tools/socktap/ethernet_device.hpp
+++ b/tools/socktap/ethernet_device.hpp
@@ -1,11 +1,13 @@
 #ifndef ETHERNET_DEVICE_HPP_NEVC5DAY
 #define ETHERNET_DEVICE_HPP_NEVC5DAY
 
+#include "network_device.hpp"
 #include <vanetza/net/mac_address.hpp>
 #include <boost/asio/generic/raw_protocol.hpp>
+#include <memory>
 #include <string>
 
-class EthernetDevice
+class EthernetDevice : public NetworkDevice
 {
 public:
     using protocol = boost::asio::generic::raw_protocol;
@@ -26,4 +28,3 @@ private:
 };
 
 #endif /* ETHERNET_DEVICE_HPP_NEVC5DAY */
-

--- a/tools/socktap/fake_network_device.cpp
+++ b/tools/socktap/fake_network_device.cpp
@@ -1,0 +1,17 @@
+#include "fake_network_device.hpp"
+
+using boost::asio::generic::raw_protocol;
+
+FakeNetworkDevice::FakeNetworkDevice(const NetworkDevice& network_device, const vanetza::MacAddress& address_override) :
+    network_device_(network_device),
+    address_override_(address_override) {}
+
+raw_protocol::endpoint FakeNetworkDevice::endpoint(int family) const
+{
+    return network_device_.endpoint(family);
+}
+
+vanetza::MacAddress FakeNetworkDevice::address() const
+{
+    return address_override_;
+}

--- a/tools/socktap/fake_network_device.hpp
+++ b/tools/socktap/fake_network_device.hpp
@@ -1,0 +1,25 @@
+#ifndef FAKE_NETWORK_DEVICE_HPP_NEVC5DAY
+#define FAKE_NETWORK_DEVICE_HPP_NEVC5DAY
+
+#include "network_device.hpp"
+#include <vanetza/net/mac_address.hpp>
+#include <boost/asio/generic/raw_protocol.hpp>
+
+class FakeNetworkDevice : public NetworkDevice
+{
+public:
+    using protocol = boost::asio::generic::raw_protocol;
+
+    FakeNetworkDevice(const NetworkDevice& network_device, const vanetza::MacAddress& address_override);
+    FakeNetworkDevice(const FakeNetworkDevice&) = delete;
+    FakeNetworkDevice& operator=(const FakeNetworkDevice&) = delete;
+
+    protocol::endpoint endpoint(int family) const;
+    vanetza::MacAddress address() const;
+
+private:
+    const NetworkDevice& network_device_;
+    const vanetza::MacAddress& address_override_;
+};
+
+#endif /* FAKE_NETWORK_DEVICE_HPP_NEVC5DAY */

--- a/tools/socktap/gps_position_provider.cpp
+++ b/tools/socktap/gps_position_provider.cpp
@@ -7,7 +7,7 @@ static_assert(GPSD_API_MAJOR_VERSION == 6, "libgps has incompatible API");
 
 GpsPositionProvider::GpsPositionProvider()
 {
-    if (gps_open(GPSD_SHARED_MEMORY, nullptr, &gps_data)) {
+    if (gps_open("127.0.0.1", "2947", &gps_data)) {
         throw gps_error(errno);
     }
     gps_stream(&gps_data, WATCH_ENABLE | WATCH_JSON, nullptr);

--- a/tools/socktap/main.cpp
+++ b/tools/socktap/main.cpp
@@ -1,4 +1,5 @@
 #include "ethernet_device.hpp"
+#include "fake_network_device.hpp"
 #include "gps_position_provider.hpp"
 #include "hello_application.hpp"
 #include "router_context.hpp"
@@ -6,28 +7,67 @@
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/asio/generic/raw_protocol.hpp>
+#include <boost/program_options.hpp>
 #include <iostream>
 
 namespace asio = boost::asio;
 namespace gn = vanetza::geonet;
+namespace po = boost::program_options;
 using namespace vanetza;
 
 int main(int argc, const char** argv)
 {
-    const char* device_name = "lo";
-    if (argc != 2) {
-        std::cout << "usage: " << argv[0] << " <device_name>\n";
-        return 0;
-    } else {
-        device_name = argv[1];
+    po::options_description options("Allowed options");
+    options.add_options()
+        ("help", "Print out available options.")
+        ("interface,i", po::value<std::string>()->default_value("lo"), "Network interface to use.")
+        ("mac-address", po::value<std::string>(), "Fake the sender MAC address.")
+    ;
+
+    po::positional_options_description positional_options;
+    positional_options.add("interface", -1);
+
+    po::variables_map vm;
+
+    try {
+        po::store(
+            po::command_line_parser(argc, argv)
+                .options(options)
+                .positional(positional_options)
+                .run(),
+            vm
+        );
+        po::notify(vm);
+    } catch (po::error& e) {
+        std::cerr << "ERROR: " << e.what() << "\n\n";
+        std::cerr << options << "\n";
+        return 1;
+    }
+
+    if (vm.count("help")) {
+        std::cout << options << "\n";
+        return 1;
     }
 
     try {
         asio::io_service io_service;
-        EthernetDevice device(device_name);
+        vanetza::MacAddress address;
+        NetworkDevice *device = new EthernetDevice(vm["interface"].as<std::string>().c_str());
+
+        if (vm.count("mac-address")) {
+            std::cout << "Using MAC address: " << vm["mac-address"].as<std::string>() << ".\n";
+
+            if (!parse_mac_address(vm["mac-address"].as<std::string>().c_str(), address)) {
+                std::cerr << "The specified MAC address is invalid." << "\n";
+                return 1;
+            }
+
+            device = new FakeNetworkDevice(*device, address);
+        }
+
         asio::generic::raw_protocol raw_protocol(AF_PACKET, gn::ether_type.net());
         asio::generic::raw_protocol::socket raw_socket(io_service, raw_protocol);
-        raw_socket.bind(device.endpoint(AF_PACKET));
+        raw_socket.bind(device->endpoint(AF_PACKET));
 
         auto signal_handler = [&io_service](const boost::system::error_code& ec, int signal_number) {
             if (!ec) {
@@ -40,7 +80,7 @@ int main(int argc, const char** argv)
 
         TimeTrigger trigger(io_service);
         GpsPositionProvider positioning;
-        RouterContext context(raw_socket, device, trigger, positioning);
+        RouterContext context(raw_socket, *device, trigger, positioning);
 
         asio::steady_timer hello_timer(io_service);
         HelloApplication hello_app(hello_timer);

--- a/tools/socktap/network_device.hpp
+++ b/tools/socktap/network_device.hpp
@@ -1,0 +1,16 @@
+#ifndef NETWORK_DEVICE_HPP_NEVC5DAY
+#define NETWORK_DEVICE_HPP_NEVC5DAY
+
+#include <vanetza/net/mac_address.hpp>
+#include <boost/asio/generic/raw_protocol.hpp>
+
+class NetworkDevice
+{
+public:
+    using protocol = boost::asio::generic::raw_protocol;
+
+    virtual protocol::endpoint endpoint(int family) const = 0;
+    virtual vanetza::MacAddress address() const = 0;
+};
+
+#endif /* NETWORK_DEVICE_HPP_NEVC5DAY */

--- a/tools/socktap/router_context.cpp
+++ b/tools/socktap/router_context.cpp
@@ -1,4 +1,5 @@
 #include "application.hpp"
+#include "dcc_passthrough.hpp"
 #include "ethernet_device.hpp"
 #include "position_provider.hpp"
 #include "router_context.hpp"
@@ -13,41 +14,11 @@ namespace asio = boost::asio;
 using boost::asio::generic::raw_protocol;
 using namespace vanetza;
 
-class DccPassthrough : public dcc::RequestInterface
-{
-public:
-    DccPassthrough(raw_protocol::socket& socket, TimeTrigger& trigger) :
-        socket_(socket), trigger_(trigger) {}
-
-    void request(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket> packet)
-    {
-        buffers_[0] = create_ethernet_header(request.destination, request.source, request.ether_type);
-        for (auto& layer : osi_layer_range<OsiLayer::Network, OsiLayer::Application>()) {
-            const auto index = distance(OsiLayer::Link, layer);
-            packet->layer(layer).convert(buffers_[index]);
-        }
-
-        trigger_.schedule();
-
-        std::array<asio::const_buffer, layers_> const_buffers;
-        for (unsigned i = 0; i < const_buffers.size(); ++i) {
-            const_buffers[i] = asio::buffer(buffers_[i]);
-        }
-        auto bytes_sent = socket_.send(const_buffers);
-        std::cout << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
-    }
-
-private:
-    static constexpr std::size_t layers_ = num_osi_layers(OsiLayer::Link, OsiLayer::Application);
-    raw_protocol::socket& socket_;
-    std::array<ByteBuffer, layers_> buffers_;
-    TimeTrigger& trigger_;
-};
-
 geonet::MIB configure_mib(const EthernetDevice& device)
 {
     geonet::MIB mib;
     mib.itsGnLocalGnAddr.mid(device.address());
+    mib.itsGnLocalGnAddr.is_manually_configured(true);
     mib.itsGnLocalAddrConfMethod = geonet::AddrConfMethod::MANAGED;
     mib.itsGnSecurity = false;
     return mib;
@@ -123,9 +94,14 @@ void RouterContext::enable(Application* app)
 
 void RouterContext::update_position_vector()
 {
-    router_.update(positioning_.current_position());
+    auto position = positioning_.current_position();
+
+    router_.update(position);
     vanetza::Runtime::Callback callback = [this](vanetza::Clock::time_point) { this->update_position_vector(); };
     vanetza::Clock::duration next = std::chrono::seconds(1);
     trigger_.runtime().schedule(next, callback);
     trigger_.schedule();
+
+    // Skip all requests until a valid GPS position is available
+    request_interface_.get()->allow_packet_flow(position.position_accuracy_indicator);
 }

--- a/tools/socktap/router_context.cpp
+++ b/tools/socktap/router_context.cpp
@@ -1,6 +1,6 @@
 #include "application.hpp"
 #include "dcc_passthrough.hpp"
-#include "ethernet_device.hpp"
+#include "network_device.hpp"
 #include "position_provider.hpp"
 #include "router_context.hpp"
 #include "time_trigger.hpp"
@@ -14,7 +14,7 @@ namespace asio = boost::asio;
 using boost::asio::generic::raw_protocol;
 using namespace vanetza;
 
-geonet::MIB configure_mib(const EthernetDevice& device)
+geonet::MIB configure_mib(const NetworkDevice& device)
 {
     geonet::MIB mib;
     mib.itsGnLocalGnAddr.mid(device.address());
@@ -24,7 +24,7 @@ geonet::MIB configure_mib(const EthernetDevice& device)
     return mib;
 }
 
-RouterContext::RouterContext(raw_protocol::socket& socket, const EthernetDevice& device, TimeTrigger& trigger, PositionProvider& positioning) :
+RouterContext::RouterContext(raw_protocol::socket& socket, const NetworkDevice& device, TimeTrigger& trigger, PositionProvider& positioning) :
     mib_(configure_mib(device)), router_(trigger.runtime(), mib_),
     socket_(socket), device_(device), trigger_(trigger), positioning_(positioning),
     request_interface_(new DccPassthrough(socket, trigger)),

--- a/tools/socktap/router_context.hpp
+++ b/tools/socktap/router_context.hpp
@@ -1,6 +1,7 @@
 #ifndef ROUTER_CONTEXT_HPP_KIPUYBY2
 #define ROUTER_CONTEXT_HPP_KIPUYBY2
 
+#include "dcc_passthrough.hpp"
 #include <vanetza/btp/port_dispatcher.hpp>
 #include <vanetza/geonet/mib.hpp>
 #include <vanetza/geonet/router.hpp>
@@ -37,11 +38,10 @@ private:
     TimeTrigger& trigger_;
     PositionProvider& positioning_;
     vanetza::btp::PortDispatcher dispatcher_;
-    std::unique_ptr<vanetza::dcc::RequestInterface> request_interface_;
+    std::unique_ptr<DccPassthrough> request_interface_;
     vanetza::ByteBuffer receive_buffer_;
     boost::asio::generic::raw_protocol::endpoint receive_endpoint_;
     std::list<Application*> applications_;
 };
 
 #endif /* ROUTER_CONTEXT_HPP_KIPUYBY2 */
-

--- a/tools/socktap/router_context.hpp
+++ b/tools/socktap/router_context.hpp
@@ -2,6 +2,7 @@
 #define ROUTER_CONTEXT_HPP_KIPUYBY2
 
 #include "dcc_passthrough.hpp"
+#include "network_device.hpp"
 #include <vanetza/btp/port_dispatcher.hpp>
 #include <vanetza/geonet/mib.hpp>
 #include <vanetza/geonet/router.hpp>
@@ -13,14 +14,13 @@
 #include <memory>
 
 class Application;
-class EthernetDevice;
 class PositionProvider;
 class TimeTrigger;
 
 class RouterContext
 {
 public:
-    RouterContext(boost::asio::generic::raw_protocol::socket&, const EthernetDevice&, TimeTrigger&, PositionProvider&);
+    RouterContext(boost::asio::generic::raw_protocol::socket&, const NetworkDevice&, TimeTrigger&, PositionProvider&);
     ~RouterContext();
     void enable(Application*);
 
@@ -34,7 +34,7 @@ private:
     vanetza::geonet::MIB mib_;
     vanetza::geonet::Router router_;
     boost::asio::generic::raw_protocol::socket& socket_;
-    const EthernetDevice& device_;
+    const NetworkDevice& device_;
     TimeTrigger& trigger_;
     PositionProvider& positioning_;
     vanetza::btp::PortDispatcher dispatcher_;


### PR DESCRIPTION
This builds on #7.

This adds runtime options to socktap and includes a mechanism to fake the sender MAC address. It allows running socktap on the loopback interface with two different addresses easily.