### PR TITLE
socktap: Implement optional security

### DIFF
--- a/tools/socktap/main.cpp
+++ b/tools/socktap/main.cpp
@@ -8,6 +8,8 @@
 #include <boost/asio/generic/raw_protocol.hpp>
 #include <boost/program_options.hpp>
 #include <iostream>
+#include <vanetza/security/naive_certificate_manager.hpp>
+#include <vanetza/security/security_entity.hpp>
 
 namespace asio = boost::asio;
 namespace gn = vanetza::geonet;
@@ -21,6 +23,7 @@ int main(int argc, const char** argv)
         ("help", "Print out available options.")
         ("interface,i", po::value<std::string>()->default_value("lo"), "Network interface to use.")
         ("mac-address", po::value<std::string>(), "Override the network interface's MAC address.")
+        ("security", po::value<std::string>()->default_value("off"), "Security profile to use.")
         ("gpsd-host", po::value<std::string>()->default_value(gpsd::shared_memory), "gpsd's server hostname")
         ("gpsd-port", po::value<std::string>()->default_value(gpsd::default_port), "gpsd's listening port")
         ("require-gnss-fix", "suppress transmissions while GNSS position fix is missing")
@@ -85,11 +88,35 @@ int main(int argc, const char** argv)
         mib.itsGnLocalGnAddr.mid(mac_address);
         mib.itsGnLocalGnAddr.is_manually_configured(true);
         mib.itsGnLocalAddrConfMethod = geonet::AddrConfMethod::MANAGED;
-        mib.itsGnSecurity = false;
 
         TimeTrigger trigger(io_service);
+
+        std::string securitySetting = vm["security"].as<std::string>();
+
+        // We always use the same ceritificate manager and crypto services for now.
+        // If itsGnSecurity is false, no signing will be performed, but receiving of signed messages works as expected.
+        auto certificate_manager_factory = security::builtin_certificate_managers();
+        auto certificate_manager = certificate_manager_factory.create("Naive", trigger.runtime());
+
+        auto crypto_backend = security::create_backend("default");
+
+        security::SignService sign_service = straight_sign_service(trigger.runtime(), *certificate_manager, *crypto_backend);
+        security::VerifyService verify_service = dummy_verify_service(security::VerificationReport::Success, security::CertificateValidity::valid());
+
+        if (securitySetting == "off") {
+            mib.itsGnSecurity = false;
+        } else if (securitySetting == "naive") {
+            mib.itsGnSecurity = true;
+        } else {
+            std::cerr << "Invalid security value '" << securitySetting << "', defaulting to 'off'." << "\n";
+            mib.itsGnSecurity = false;
+        }
+
         GpsPositionProvider positioning(vm["gpsd-host"].as<std::string>(), vm["gpsd-port"].as<std::string>());
-        RouterContext context(raw_socket, mib, trigger, positioning);
+
+        security::SecurityEntity security_entity(sign_service, verify_service);
+
+        RouterContext context(raw_socket, mib, trigger, positioning, security_entity);
         context.require_position_fix(vm.count("require-gnss-fix") > 0);
 
         asio::steady_timer hello_timer(io_service);

--- a/tools/socktap/router_context.cpp
+++ b/tools/socktap/router_context.cpp
@@ -14,7 +14,7 @@ namespace asio = boost::asio;
 using boost::asio::generic::raw_protocol;
 using namespace vanetza;
 
-RouterContext::RouterContext(raw_protocol::socket& socket, const geonet::MIB& mib, TimeTrigger& trigger, PositionProvider& positioning) :
+RouterContext::RouterContext(raw_protocol::socket& socket, const geonet::MIB& mib, TimeTrigger& trigger, PositionProvider& positioning, vanetza::security::SecurityEntity& security_entity) :
     mib_(mib), router_(trigger.runtime(), mib_),
     socket_(socket), trigger_(trigger), positioning_(positioning),
     request_interface_(new DccPassthrough(socket, trigger)),
@@ -24,10 +24,10 @@ RouterContext::RouterContext(raw_protocol::socket& socket, const geonet::MIB& mi
     router_.set_address(mib_.itsGnLocalGnAddr);
     router_.set_access_interface(request_interface_.get());
     router_.set_transport_handler(geonet::UpperProtocol::BTP_B, &dispatcher_);
-    update_position_vector();
+    router_.set_security_entity(&security_entity);
 
+    update_position_vector();
     do_receive();
-    trigger_.schedule();
 }
 
 RouterContext::~RouterContext()
@@ -109,4 +109,3 @@ void RouterContext::update_packet_flow(const geonet::LongPositionVector& lpv)
         request_interface_->allow_packet_flow(true);
     }
 }
-

--- a/tools/socktap/router_context.hpp
+++ b/tools/socktap/router_context.hpp
@@ -19,7 +19,7 @@ class TimeTrigger;
 class RouterContext
 {
 public:
-    RouterContext(boost::asio::generic::raw_protocol::socket&, const vanetza::geonet::MIB&, TimeTrigger&, PositionProvider&);
+    RouterContext(boost::asio::generic::raw_protocol::socket&, const vanetza::geonet::MIB&, TimeTrigger&, PositionProvider&, vanetza::security::SecurityEntity&);
     ~RouterContext();
     void enable(Application*);
 


### PR DESCRIPTION
`--security` can be set to either `'off'` or `'naive'` to sign messages. Signed messages are currently not validated, but always pass as OK.