### PR TITLE
Reject certificates without supported time constraint

### DIFF
--- a/vanetza/security/naive_certificate_manager.cpp
+++ b/vanetza/security/naive_certificate_manager.cpp
@@ -111,6 +111,8 @@ CertificateValidity NaiveCertificateManager::check_certificate(const Certificate
 
             certificate_has_time_constraint = true;
         }
+
+        // TODO: Support time_start_and_duration and time_end
     }
 
     // if no time constraint is given, we fail instead of considering it valid


### PR DESCRIPTION
Certificates should always have a time constraint. Currently only `time_start_and_end` is supported. If no such constraint is given, certificates were not rejected before. That means any certificate using `time_end` or `time_start_and_duration` was simply deemed valid.