### PR TITLE
Add support for time_end in NaiveCertificateManager

### DIFF
--- a/vanetza/security/naive_certificate_manager.cpp
+++ b/vanetza/security/naive_certificate_manager.cpp
@@ -120,9 +120,18 @@ CertificateValidity NaiveCertificateManager::check_certificate(const Certificate
             }
 
             certificate_has_time_constraint = true;
-        }
+        } else if (type == ValidityRestrictionType::Time_Start_And_Duration) {
+            StartAndDurationValidity start_and_duration = boost::get<StartAndDurationValidity>(validity_restriction);
 
-        // TODO: Support time_start_and_duration
+            // check if certificate is premature or outdated
+            auto now = convert_time32(m_time_now);
+            auto end = start_and_duration.start_validity + std::chrono::duration_cast<std::chrono::milliseconds>(start_and_duration.duration.to_seconds()).count();
+            if (now < start_and_duration.start_validity || now > end) {
+                return CertificateInvalidReason::OFF_TIME_PERIOD;
+            }
+
+            certificate_has_time_constraint = true;
+        }
     }
 
     // if no time constraint is given, we fail instead of considering it valid

--- a/vanetza/security/naive_certificate_manager.cpp
+++ b/vanetza/security/naive_certificate_manager.cpp
@@ -125,7 +125,7 @@ CertificateValidity NaiveCertificateManager::check_certificate(const Certificate
 
             // check if certificate is premature or outdated
             auto now = convert_time32(m_time_now);
-            auto end = start_and_duration.start_validity + std::chrono::duration_cast<std::chrono::milliseconds>(start_and_duration.duration.to_seconds()).count();
+            auto end = start_and_duration.start_validity + std::chrono::duration_cast<std::chrono::seconds>(start_and_duration.duration.to_seconds()).count();
             if (now < start_and_duration.start_validity || now > end) {
                 return CertificateInvalidReason::OFF_TIME_PERIOD;
             }

--- a/vanetza/security/naive_certificate_manager.cpp
+++ b/vanetza/security/naive_certificate_manager.cpp
@@ -110,9 +110,19 @@ CertificateValidity NaiveCertificateManager::check_certificate(const Certificate
             }
 
             certificate_has_time_constraint = true;
+        } else if (type == ValidityRestrictionType::Time_End) {
+            EndValidity end = boost::get<EndValidity>(validity_restriction);
+
+            // check if certificate is outdated
+            auto now = convert_time32(m_time_now);
+            if (now > end) {
+                return CertificateInvalidReason::OFF_TIME_PERIOD;
+            }
+
+            certificate_has_time_constraint = true;
         }
 
-        // TODO: Support time_start_and_duration and time_end
+        // TODO: Support time_start_and_duration
     }
 
     // if no time constraint is given, we fail instead of considering it valid

--- a/vanetza/security/tests/validity_restriction.cpp
+++ b/vanetza/security/tests/validity_restriction.cpp
@@ -6,7 +6,7 @@
 
 using namespace vanetza::security;
 
-TEST(Duration, Duration)
+TEST(Duration, Raw)
 {
     uint16_t a = 0x8007;
     uint16_t b = 7;
@@ -16,6 +16,37 @@ TEST(Duration, Duration)
 
     EXPECT_EQ(dur1.raw(), a);
     EXPECT_EQ(dur2.raw(), a);
+}
+
+TEST(Duration, Unit)
+{
+    uint16_t raw = 0x8007;
+
+    Duration duration(raw);
+
+    EXPECT_EQ(duration.raw(), raw);
+    EXPECT_EQ(duration.unit(), Duration::Units::Years);
+}
+
+TEST(Duration, Value)
+{
+    uint16_t raw = 0x8007;
+
+    Duration duration(raw);
+
+    EXPECT_EQ(duration.raw(), raw);
+    EXPECT_EQ(duration.value(), 7);
+}
+
+TEST(Duration, Duration)
+{
+    uint16_t raw = 0x2007;
+
+    Duration duration(raw);
+
+    EXPECT_EQ(duration.raw(), raw);
+    EXPECT_EQ(duration.value(), 7);
+    EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(duration.to_seconds()).count(), 7 * 60);
 }
 
 TEST(ValidityRestriction, Serialization)

--- a/vanetza/security/validity_restriction.cpp
+++ b/vanetza/security/validity_restriction.cpp
@@ -21,6 +21,31 @@ Duration::Duration(uint16_t raw) : m_raw(raw)
 {
 }
 
+std::chrono::seconds Duration::to_seconds() const
+{
+    // see section 4.2.17 of TS 103 097 v1.2.1
+    switch (unit()) {
+        case Units::Seconds:
+            return std::chrono::seconds(value());
+
+        case Units::Minutes:
+            return std::chrono::seconds(value() * 60);
+
+        case Units::Hours:
+            return std::chrono::seconds(value() * 3600);
+
+        case Units::Sixty_Hour_Blocks:
+            return std::chrono::seconds(value() * 216000);
+
+        case Units::Years:
+            return std::chrono::seconds(value() * 31556925);
+
+        default:
+            // undefined, let's interpret it as a duration of 0, which will fail during validation
+            return std::chrono::seconds(0);
+    }
+}
+
 StartAndEndValidity::StartAndEndValidity(Time32 start, Time32 end) :
     start_validity(start), end_validity(end) {}
 

--- a/vanetza/security/validity_restriction.hpp
+++ b/vanetza/security/validity_restriction.hpp
@@ -5,6 +5,7 @@
 #include <vanetza/security/region.hpp>
 #include <vanetza/security/serialization.hpp>
 #include <boost/variant/variant.hpp>
+#include <chrono>
 
 namespace vanetza
 {
@@ -34,6 +35,24 @@ public:
     {
         return m_raw;
     }
+
+    /**
+     * Returns the duration unit.
+     */
+    Units unit() const
+    {
+        return static_cast<Units>(m_raw >> 13);
+    }
+
+    uint16_t value() const
+    {
+        return m_raw & 0xCFFF; // mask upper 3 bit
+    }
+
+    /**
+     * Returns the duration in seconds.
+     */
+    std::chrono::seconds to_seconds() const;
 
 private:
     uint16_t m_raw;
@@ -108,4 +127,3 @@ void serialize(OutputArchive&, const ValidityRestriction&);
 } // namespace vanetza
 
 #endif /* VALIDITY_RESTRICTION_HPP_LMCUHYLJ */
-

--- a/vanetza/security/validity_restriction.hpp
+++ b/vanetza/security/validity_restriction.hpp
@@ -46,7 +46,7 @@ public:
 
     uint16_t value() const
     {
-        return m_raw & 0xCFFF; // mask upper 3 bit
+        return m_raw & 0x1FFF; // mask upper 3 bit
     }
 
     /**


### PR DESCRIPTION
I can also add support for `time_start_and_duration`, but I'm not sure which unit to use, as the unit for `Duration` can be years.