### PR TITLE
Add 'tags' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 conanfile.pyc
 doc/*/
+tags


### PR DESCRIPTION
File used by Atom for autocomplete powered by ctags.