### PR TITLE
certify: New command line tool for certificates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(BUILD_SOCKTAP)
 endif()
 
 option(BUILD_CERTIFY "Build certify application" OFF)
-if(BUILD_SOCKTAP)
+if(BUILD_CERTIFY)
   add_subdirectory(tools/certify)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,11 @@ if(BUILD_SOCKTAP)
   add_subdirectory(tools/socktap)
 endif()
 
+option(BUILD_CERTIFY "Build certify application" OFF)
+if(BUILD_SOCKTAP)
+  add_subdirectory(tools/certify)
+endif()
+
 # interface library for convenience
 get_property(_components GLOBAL PROPERTY VANETZA_COMPONENTS)
 add_library(vanetza INTERFACE)
@@ -110,4 +115,3 @@ file(COPY ${CMAKECONFIG_BUILD_DIR}/VanetzaConfigVersion.cmake
 configure_file(cmake/VanetzaExportsConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/VanetzaConfig.cmake @ONLY)
 export(PACKAGE ${PROJECT_NAME})
-

--- a/tools/certify/CMakeLists.txt
+++ b/tools/certify/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 find_package(Threads REQUIRED)
 find_package(GPS REQUIRED)
 
+include_directories(.)
+
 add_executable(certify
     commands/auth-ca.cpp
     commands/genkey.cpp

--- a/tools/certify/CMakeLists.txt
+++ b/tools/certify/CMakeLists.txt
@@ -1,0 +1,24 @@
+if(NOT TARGET Boost::system)
+    message(STATUS "Skip build of certify because of missing Boost::system dependency")
+    return()
+endif()
+
+if(NOT TARGET Boost::program_options)
+    message(STATUS "Skip build of certify because of missing Boost::program_options dependency")
+    return()
+endif()
+
+find_package(Threads REQUIRED)
+find_package(GPS REQUIRED)
+
+add_executable(certify
+    commands/auth-ca.cpp
+    commands/genkey.cpp
+    commands/root-ca.cpp
+    commands/sign-ticket.cpp
+    keyio.cpp
+    main.cpp
+    options.cpp
+)
+
+target_link_libraries(certify Boost::system Boost::program_options Threads::Threads vanetza)

--- a/tools/certify/command.hpp
+++ b/tools/certify/command.hpp
@@ -1,0 +1,13 @@
+#ifndef CERTIFY_COMMAND_HPP
+#define CERTIFY_COMMAND_HPP
+
+#include <boost/program_options.hpp>
+
+class Command
+{
+public:
+    virtual int execute() = 0;
+    virtual void parse(std::vector<std::string>&) = 0;
+};
+
+#endif /* CERTIFY_COMMAND_HPP */

--- a/tools/certify/command.hpp
+++ b/tools/certify/command.hpp
@@ -1,7 +1,8 @@
 #ifndef CERTIFY_COMMAND_HPP
 #define CERTIFY_COMMAND_HPP
 
-#include <boost/program_options.hpp>
+#include <string>
+#include <vector>
 
 class Command
 {

--- a/tools/certify/commands/auth-ca.cpp
+++ b/tools/certify/commands/auth-ca.cpp
@@ -1,6 +1,7 @@
-#include "../keyio.hpp"
 #include "auth-ca.hpp"
+#include "keyio.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
 #include <chrono>
 #include <cryptopp/eccrypto.h>
 #include <cryptopp/oids.h>

--- a/tools/certify/commands/auth-ca.cpp
+++ b/tools/certify/commands/auth-ca.cpp
@@ -1,0 +1,127 @@
+#include "../keyio.hpp"
+#include "auth-ca.hpp"
+#include <boost/filesystem.hpp>
+#include <chrono>
+#include <cryptopp/eccrypto.h>
+#include <cryptopp/oids.h>
+#include <cryptopp/osrng.h>
+#include <cryptopp/queue.h>
+#include <cryptopp/sha.h>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <vanetza/common/clock.hpp>
+#include <vanetza/security/backend_cryptopp.hpp>
+#include <vanetza/security/basic_elements.hpp>
+#include <vanetza/security/certificate.hpp>
+#include <vanetza/security/subject_attribute.hpp>
+#include <vanetza/security/subject_info.hpp>
+
+namespace po = boost::program_options;
+namespace vs = vanetza::security;
+using namespace CryptoPP;
+
+void AuthCaCommand::parse(std::vector<std::string>& opts)
+{
+    po::options_description desc("auth-ca options");
+    desc.add_options()
+        ("output", po::value<std::string>(&output)->required(), "Output file.")
+        ("sign-key", po::value<std::string>(&sign_key)->required(), "Private key file of the signer.")
+        ("sign-cert", po::value<std::string>(&sign_cert)->required(), "Private certificate file of the signer.")
+        ("subject-key", po::value<std::string>(&subject_key)->required(), "Private key file to issue the certificate for.")
+        ("subject-name", po::value<std::string>(&subject_name)->default_value("Hello World Auth-CA"), "Subject name.")
+        ("days", po::value<int>(&validity_days)->default_value(180), "Validity in days.")
+    ;
+
+    po::positional_options_description pos;
+    pos.add("output", 1);
+
+    po::variables_map vm;
+    po::store(po::command_line_parser(opts).options(desc).positional(pos).run(), vm);
+    po::notify(vm);
+}
+
+int AuthCaCommand::execute()
+{
+    std::cout << "Loading keys... ";
+
+    AutoSeededRandomPool rng;
+    vs::BackendCryptoPP crypto_backend;
+
+    ECDSA<ECP, SHA256>::PrivateKey loaded_sign_key;
+    ECDSA<ECP, SHA256>::PrivateKey loaded_subject_key;
+
+    ByteQueue queue;
+    load_key(sign_key, queue);
+    loaded_sign_key.Load(queue);
+
+    if (!loaded_sign_key.Validate(rng, 3)) {
+        throw std::runtime_error("Private key validation failed for sign key");
+    }
+
+    queue.Clear();
+    load_key(subject_key, queue);
+    loaded_subject_key.Load(queue);
+
+    if (!loaded_subject_key.Validate(rng, 3)) {
+        throw std::runtime_error("Private key validation failed for subject key");
+    }
+
+    std::cout << "OK" << std::endl;
+
+    vs::Certificate loaded_sign_cert;
+
+    std::ifstream src;
+    src.open(sign_cert.c_str(), std::ios::in | std::ios::binary);
+
+    vanetza::InputArchive iarchive(src);
+    vs::deserialize(iarchive, loaded_sign_cert);
+
+    auto sign_key_pair = to_keypair(loaded_sign_key);
+    auto subject_key_pair = to_keypair(loaded_subject_key);
+    auto time_now = vanetza::Clock::at(boost::posix_time::microsec_clock::universal_time());
+
+    vs::Certificate certificate;
+
+    certificate.signer_info = vs::calculate_hash(loaded_sign_cert);
+
+    std::vector<unsigned char> subject(subject_name.c_str(), subject_name.c_str() + subject_name.size() + 1);
+    certificate.subject_info.subject_name = subject;
+    certificate.subject_info.subject_type = vs::SubjectType::Authorization_Authority;
+
+    certificate.subject_attributes.push_back(vs::SubjectAssurance(0x00));
+
+    vs::Uncompressed coordinates;
+    coordinates.x.assign(subject_key_pair.public_key.x.begin(), subject_key_pair.public_key.x.end());
+    coordinates.y.assign(subject_key_pair.public_key.y.begin(), subject_key_pair.public_key.y.end());
+    vs::EccPoint ecc_point = coordinates;
+    vs::ecdsa_nistp256_with_sha256 ecdsa;
+    ecdsa.public_key = ecc_point;
+    vs::VerificationKey verification_key;
+    verification_key.key = ecdsa;
+    certificate.subject_attributes.push_back(verification_key);
+
+    vs::StartAndEndValidity start_and_end;
+    start_and_end.start_validity = vs::convert_time32(time_now - std::chrono::hours(1));
+    start_and_end.end_validity = vs::convert_time32(time_now + std::chrono::hours(24 * validity_days));
+    certificate.validity_restriction.push_back(start_and_end);
+
+    std::cout << "Signing certificate... ";
+
+    vanetza::ByteBuffer data_buffer = vs::convert_for_signing(certificate);
+    certificate.signature = crypto_backend.sign_data(sign_key_pair.private_key, data_buffer);
+
+    std::cout << "OK" << std::endl;
+
+    std::cout << "Writing certificate to '" << output << "'... ";
+
+    std::ofstream dest;
+    dest.open(output.c_str(), std::ios::out | std::ios::binary);
+
+    vanetza::OutputArchive archive(dest);
+    vs::serialize(archive, certificate);
+
+    std::cout << "OK" << std::endl;
+
+    return 0;
+}

--- a/tools/certify/commands/auth-ca.hpp
+++ b/tools/certify/commands/auth-ca.hpp
@@ -1,0 +1,20 @@
+#ifndef CERTIFY_COMMANDS_AUTH_CA_HPP
+#define CERTIFY_COMMANDS_AUTH_CA_HPP
+
+#include "../command.hpp"
+#include <string>
+
+class AuthCaCommand : public Command {
+public:
+    std::string output;
+    std::string sign_key;
+    std::string sign_cert;
+    std::string subject_key;
+    std::string subject_name;
+    int validity_days;
+
+    void parse(std::vector<std::string>&) override;
+    int execute() override;
+};
+
+#endif /* CERTIFY_COMMANDS_AUTH_CA_HPP */

--- a/tools/certify/commands/auth-ca.hpp
+++ b/tools/certify/commands/auth-ca.hpp
@@ -1,20 +1,20 @@
 #ifndef CERTIFY_COMMANDS_AUTH_CA_HPP
 #define CERTIFY_COMMANDS_AUTH_CA_HPP
 
-#include "../command.hpp"
-#include <string>
+#include "command.hpp"
 
 class AuthCaCommand : public Command {
 public:
+    void parse(std::vector<std::string>&) override;
+    int execute() override;
+
+private:
     std::string output;
     std::string sign_key;
     std::string sign_cert;
     std::string subject_key;
     std::string subject_name;
     int validity_days;
-
-    void parse(std::vector<std::string>&) override;
-    int execute() override;
 };
 
 #endif /* CERTIFY_COMMANDS_AUTH_CA_HPP */

--- a/tools/certify/commands/genkey.cpp
+++ b/tools/certify/commands/genkey.cpp
@@ -1,6 +1,6 @@
-#include "../keyio.hpp"
 #include "genkey.hpp"
-#include <vanetza/security/backend_cryptopp.hpp>
+#include "keyio.hpp"
+#include <boost/program_options.hpp>
 #include <cryptopp/eccrypto.h>
 #include <cryptopp/files.h>
 #include <cryptopp/oids.h>
@@ -9,6 +9,7 @@
 #include <cryptopp/sha.h>
 #include <iostream>
 #include <stdexcept>
+#include <vanetza/security/backend_cryptopp.hpp>
 
 namespace po = boost::program_options;
 using namespace CryptoPP;

--- a/tools/certify/commands/genkey.cpp
+++ b/tools/certify/commands/genkey.cpp
@@ -1,0 +1,49 @@
+#include "../keyio.hpp"
+#include "genkey.hpp"
+#include <vanetza/security/backend_cryptopp.hpp>
+#include <cryptopp/eccrypto.h>
+#include <cryptopp/files.h>
+#include <cryptopp/oids.h>
+#include <cryptopp/osrng.h>
+#include <cryptopp/queue.h>
+#include <cryptopp/sha.h>
+#include <iostream>
+#include <stdexcept>
+
+namespace po = boost::program_options;
+using namespace CryptoPP;
+
+void GenkeyCommand::parse(std::vector<std::string>& opts)
+{
+    po::options_description desc("genkey options");
+    desc.add_options()
+        ("output", po::value<std::string>(&output)->required(), "Output file.")
+    ;
+
+    po::positional_options_description pos;
+    pos.add("output", 1);
+
+    po::variables_map vm;
+    po::store(po::command_line_parser(opts).options(desc).positional(pos).run(), vm);
+    po::notify(vm);
+}
+
+int GenkeyCommand::execute()
+{
+    std::cout << "Generating key..." << std::endl;
+
+    AutoSeededRandomPool rng;
+    OID oid(CryptoPP::ASN1::secp256r1());
+    ECDSA<ECP, SHA256>::PrivateKey private_key;
+    private_key.Initialize(rng, oid);
+
+    if (!private_key.Validate(rng, 3)) {
+        throw std::runtime_error("Private key validation failed");
+    }
+
+    ByteQueue queue;
+    private_key.Save(queue);
+    save_key(output, queue);
+
+    return 0;
+}

--- a/tools/certify/commands/genkey.hpp
+++ b/tools/certify/commands/genkey.hpp
@@ -1,0 +1,15 @@
+#ifndef CERTIFY_COMMANDS_GENKEY_HPP
+#define CERTIFY_COMMANDS_GENKEY_HPP
+
+#include "../command.hpp"
+#include <string>
+
+class GenkeyCommand : public Command {
+public:
+    std::string output;
+
+    void parse(std::vector<std::string>&) override;
+    int execute() override;
+};
+
+#endif /* CERTIFY_COMMANDS_GENKEY_HPP */

--- a/tools/certify/commands/genkey.hpp
+++ b/tools/certify/commands/genkey.hpp
@@ -1,15 +1,15 @@
 #ifndef CERTIFY_COMMANDS_GENKEY_HPP
 #define CERTIFY_COMMANDS_GENKEY_HPP
 
-#include "../command.hpp"
-#include <string>
+#include "command.hpp"
 
 class GenkeyCommand : public Command {
 public:
-    std::string output;
-
     void parse(std::vector<std::string>&) override;
     int execute() override;
+
+private:
+    std::string output;
 };
 
 #endif /* CERTIFY_COMMANDS_GENKEY_HPP */

--- a/tools/certify/commands/root-ca.cpp
+++ b/tools/certify/commands/root-ca.cpp
@@ -1,0 +1,118 @@
+#include "../keyio.hpp"
+#include "root-ca.hpp"
+#include <boost/filesystem.hpp>
+#include <chrono>
+#include <cryptopp/eccrypto.h>
+#include <cryptopp/oids.h>
+#include <cryptopp/osrng.h>
+#include <cryptopp/queue.h>
+#include <cryptopp/sha.h>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <vanetza/common/clock.hpp>
+#include <vanetza/security/backend_cryptopp.hpp>
+#include <vanetza/security/basic_elements.hpp>
+#include <vanetza/security/certificate.hpp>
+#include <vanetza/security/subject_attribute.hpp>
+#include <vanetza/security/subject_info.hpp>
+
+namespace po = boost::program_options;
+namespace vs = vanetza::security;
+using namespace CryptoPP;
+
+void RootCaCommand::parse(std::vector<std::string>& opts)
+{
+    po::options_description desc("root-ca options");
+    desc.add_options()
+        ("output", po::value<std::string>(&output)->required(), "Output file.")
+        ("cert-key", po::value<std::string>(&cert_key)->required(), "Private key file.")
+        ("subject-name", po::value<std::string>(&subject_name)->default_value("Hello World Root-CA"), "Subject name.")
+        ("days", po::value<int>(&validity_days)->default_value(365), "Validity in days.")
+    ;
+
+    po::positional_options_description pos;
+    pos.add("output", 1);
+
+    po::variables_map vm;
+    po::store(po::command_line_parser(opts).options(desc).positional(pos).run(), vm);
+    po::notify(vm);
+}
+
+int RootCaCommand::execute()
+{
+    std::cout << "Loading key... ";
+
+    AutoSeededRandomPool rng;
+    vs::BackendCryptoPP crypto_backend;
+    ECDSA<ECP, SHA256>::PrivateKey private_key;
+
+    ByteQueue queue;
+    load_key(cert_key, queue);
+    private_key.Load(queue);
+
+    if (!private_key.Validate(rng, 3)) {
+        throw std::runtime_error("Private key validation failed");
+    }
+
+    std::cout << "OK" << std::endl;
+
+    auto key_pair = to_keypair(private_key);
+    auto time_now = vanetza::Clock::at(boost::posix_time::microsec_clock::universal_time());
+
+    // create certificate
+    vs::Certificate certificate;
+
+    // section 6.1 in TS 103 097 v1.2.1
+    certificate.signer_info = nullptr; /* self */
+
+    // section 6.3 in TS 103 097 v1.2.1
+    certificate.subject_info.subject_type = vs::SubjectType::Root_Ca;
+
+    // section 7.4.2 in TS 103 097 v1.2.1
+    std::vector<unsigned char> subject(subject_name.c_str(), subject_name.c_str() + subject_name.size() + 1);
+    certificate.subject_info.subject_name = subject;
+
+    // section 6.6 in TS 103 097 v1.2.1 - levels currently undefined
+    certificate.subject_attributes.push_back(vs::SubjectAssurance(0x00));
+
+    // section 7.4.1 in TS 103 097 v1.2.1
+    // set subject attributes
+    // set the verification_key
+    vs::Uncompressed coordinates;
+    coordinates.x.assign(key_pair.public_key.x.begin(), key_pair.public_key.x.end());
+    coordinates.y.assign(key_pair.public_key.y.begin(), key_pair.public_key.y.end());
+    vs::EccPoint ecc_point = coordinates;
+    vs::ecdsa_nistp256_with_sha256 ecdsa;
+    ecdsa.public_key = ecc_point;
+    vs::VerificationKey verification_key;
+    verification_key.key = ecdsa;
+    certificate.subject_attributes.push_back(verification_key);
+
+    // section 6.7 in TS 103 097 v1.2.1
+    // set validity restriction
+    vs::StartAndEndValidity start_and_end;
+    start_and_end.start_validity = vs::convert_time32(time_now - std::chrono::hours(1));
+    start_and_end.end_validity = vs::convert_time32(time_now + std::chrono::hours(24 * validity_days));
+    certificate.validity_restriction.push_back(start_and_end);
+
+    std::cout << "Signing certificate... ";
+
+    // set signature
+    vanetza::ByteBuffer data_buffer = vs::convert_for_signing(certificate);
+    certificate.signature = crypto_backend.sign_data(key_pair.private_key, data_buffer);
+
+    std::cout << "OK" << std::endl;
+
+    std::cout << "Writing certificate to '" << output << "'... ";
+
+    std::ofstream dest;
+    dest.open(output.c_str(), std::ios::out | std::ios::binary);
+
+    vanetza::OutputArchive archive(dest);
+    vs::serialize(archive, certificate);
+
+    std::cout << "OK" << std::endl;
+
+    return 0;
+}

--- a/tools/certify/commands/root-ca.cpp
+++ b/tools/certify/commands/root-ca.cpp
@@ -1,6 +1,7 @@
-#include "../keyio.hpp"
+#include "keyio.hpp"
 #include "root-ca.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
 #include <chrono>
 #include <cryptopp/eccrypto.h>
 #include <cryptopp/oids.h>

--- a/tools/certify/commands/root-ca.hpp
+++ b/tools/certify/commands/root-ca.hpp
@@ -1,0 +1,18 @@
+#ifndef CERTIFY_COMMANDS_ROOT_CA_HPP
+#define CERTIFY_COMMANDS_ROOT_CA_HPP
+
+#include "../command.hpp"
+#include <string>
+
+class RootCaCommand : public Command {
+public:
+    std::string cert_key;
+    std::string output;
+    std::string subject_name;
+    int validity_days;
+
+    void parse(std::vector<std::string>&) override;
+    int execute() override;
+};
+
+#endif /* CERTIFY_COMMANDS_ROOT_CA_HPP */

--- a/tools/certify/commands/root-ca.hpp
+++ b/tools/certify/commands/root-ca.hpp
@@ -1,18 +1,18 @@
 #ifndef CERTIFY_COMMANDS_ROOT_CA_HPP
 #define CERTIFY_COMMANDS_ROOT_CA_HPP
 
-#include "../command.hpp"
-#include <string>
+#include "command.hpp"
 
 class RootCaCommand : public Command {
 public:
+    void parse(std::vector<std::string>&) override;
+    int execute() override;
+
+private:
     std::string cert_key;
     std::string output;
     std::string subject_name;
     int validity_days;
-
-    void parse(std::vector<std::string>&) override;
-    int execute() override;
 };
 
 #endif /* CERTIFY_COMMANDS_ROOT_CA_HPP */

--- a/tools/certify/commands/sign-ticket.cpp
+++ b/tools/certify/commands/sign-ticket.cpp
@@ -1,6 +1,7 @@
-#include "../keyio.hpp"
+#include "keyio.hpp"
 #include "sign-ticket.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
 #include <chrono>
 #include <cryptopp/eccrypto.h>
 #include <cryptopp/oids.h>

--- a/tools/certify/commands/sign-ticket.cpp
+++ b/tools/certify/commands/sign-ticket.cpp
@@ -1,0 +1,122 @@
+#include "../keyio.hpp"
+#include "sign-ticket.hpp"
+#include <boost/filesystem.hpp>
+#include <chrono>
+#include <cryptopp/eccrypto.h>
+#include <cryptopp/oids.h>
+#include <cryptopp/osrng.h>
+#include <cryptopp/queue.h>
+#include <cryptopp/sha.h>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <vanetza/common/clock.hpp>
+#include <vanetza/security/backend_cryptopp.hpp>
+#include <vanetza/security/basic_elements.hpp>
+#include <vanetza/security/certificate.hpp>
+#include <vanetza/security/subject_attribute.hpp>
+#include <vanetza/security/subject_info.hpp>
+
+namespace po = boost::program_options;
+namespace vs = vanetza::security;
+using namespace CryptoPP;
+
+void SignTicketCommand::parse(std::vector<std::string>& opts)
+{
+    po::options_description desc("auth-ca options");
+    desc.add_options()
+        ("output", po::value<std::string>(&output)->required(), "Output file.")
+        ("sign-key", po::value<std::string>(&sign_key)->required(), "Private key file of the signer.")
+        ("sign-cert", po::value<std::string>(&sign_cert)->required(), "Private certificate file of the signer.")
+        ("subject-key", po::value<std::string>(&subject_key)->required(), "Private key file to issue the certificate for.")
+        ("days", po::value<int>(&validity_days)->default_value(7), "Validity in days.")
+    ;
+
+    po::positional_options_description pos;
+    pos.add("output", 1);
+
+    po::variables_map vm;
+    po::store(po::command_line_parser(opts).options(desc).positional(pos).run(), vm);
+    po::notify(vm);
+}
+
+int SignTicketCommand::execute()
+{
+    std::cout << "Loading keys... ";
+
+    AutoSeededRandomPool rng;
+    vs::BackendCryptoPP crypto_backend;
+
+    ECDSA<ECP, SHA256>::PrivateKey loaded_sign_key;
+    ECDSA<ECP, SHA256>::PrivateKey loaded_subject_key;
+
+    ByteQueue queue;
+    load_key(sign_key, queue);
+    loaded_sign_key.Load(queue);
+
+    if (!loaded_sign_key.Validate(rng, 3)) {
+        throw std::runtime_error("Private key validation failed for sign key");
+    }
+
+    queue.Clear();
+    load_key(subject_key, queue);
+    loaded_subject_key.Load(queue);
+
+    if (!loaded_subject_key.Validate(rng, 3)) {
+        throw std::runtime_error("Private key validation failed for subject key");
+    }
+
+    std::cout << "OK" << std::endl;
+
+    vs::Certificate loaded_sign_cert;
+
+    std::ifstream src;
+    src.open(sign_cert.c_str(), std::ios::in | std::ios::binary);
+
+    vanetza::InputArchive iarchive(src);
+    vs::deserialize(iarchive, loaded_sign_cert);
+
+    auto sign_key_pair = to_keypair(loaded_sign_key);
+    auto subject_key_pair = to_keypair(loaded_subject_key);
+    auto time_now = vanetza::Clock::at(boost::posix_time::microsec_clock::universal_time());
+
+    vs::Certificate certificate;
+
+    certificate.signer_info = vs::calculate_hash(loaded_sign_cert);
+    certificate.subject_info.subject_type = vs::SubjectType::Authorization_Ticket;
+    certificate.subject_attributes.push_back(vs::SubjectAssurance(0x00));
+
+    vs::Uncompressed coordinates;
+    coordinates.x.assign(subject_key_pair.public_key.x.begin(), subject_key_pair.public_key.x.end());
+    coordinates.y.assign(subject_key_pair.public_key.y.begin(), subject_key_pair.public_key.y.end());
+    vs::EccPoint ecc_point = coordinates;
+    vs::ecdsa_nistp256_with_sha256 ecdsa;
+    ecdsa.public_key = ecc_point;
+    vs::VerificationKey verification_key;
+    verification_key.key = ecdsa;
+    certificate.subject_attributes.push_back(verification_key);
+
+    vs::StartAndEndValidity start_and_end;
+    start_and_end.start_validity = vs::convert_time32(time_now - std::chrono::hours(1));
+    start_and_end.end_validity = vs::convert_time32(time_now + std::chrono::hours(24 * validity_days));
+    certificate.validity_restriction.push_back(start_and_end);
+
+    std::cout << "Signing certificate... ";
+
+    vanetza::ByteBuffer data_buffer = vs::convert_for_signing(certificate);
+    certificate.signature = crypto_backend.sign_data(sign_key_pair.private_key, data_buffer);
+
+    std::cout << "OK" << std::endl;
+
+    std::cout << "Writing certificate to '" << output << "'... ";
+
+    std::ofstream dest;
+    dest.open(output.c_str(), std::ios::out | std::ios::binary);
+
+    vanetza::OutputArchive archive(dest);
+    vs::serialize(archive, certificate);
+
+    std::cout << "OK" << std::endl;
+
+    return 0;
+}

--- a/tools/certify/commands/sign-ticket.hpp
+++ b/tools/certify/commands/sign-ticket.hpp
@@ -1,19 +1,19 @@
 #ifndef CERTIFY_COMMANDS_SIGN_TICKET_HPP
 #define CERTIFY_COMMANDS_SIGN_TICKET_HPP
 
-#include "../command.hpp"
-#include <string>
+#include "command.hpp"
 
 class SignTicketCommand : public Command {
 public:
+    void parse(std::vector<std::string>&) override;
+    int execute() override;
+
+private:
     std::string output;
     std::string sign_key;
     std::string sign_cert;
     std::string subject_key;
     int validity_days;
-
-    void parse(std::vector<std::string>&) override;
-    int execute() override;
 };
 
 #endif /* CERTIFY_COMMANDS_SIGN_TICKET_HPP */

--- a/tools/certify/commands/sign-ticket.hpp
+++ b/tools/certify/commands/sign-ticket.hpp
@@ -1,0 +1,19 @@
+#ifndef CERTIFY_COMMANDS_SIGN_TICKET_HPP
+#define CERTIFY_COMMANDS_SIGN_TICKET_HPP
+
+#include "../command.hpp"
+#include <string>
+
+class SignTicketCommand : public Command {
+public:
+    std::string output;
+    std::string sign_key;
+    std::string sign_cert;
+    std::string subject_key;
+    int validity_days;
+
+    void parse(std::vector<std::string>&) override;
+    int execute() override;
+};
+
+#endif /* CERTIFY_COMMANDS_SIGN_TICKET_HPP */

--- a/tools/certify/keyio.cpp
+++ b/tools/certify/keyio.cpp
@@ -1,0 +1,35 @@
+#include "keyio.hpp"
+#include <cryptopp/files.h>
+
+void save_key(const std::string& filename, const CryptoPP::BufferedTransformation& bt)
+{
+    CryptoPP::FileSink file(filename.c_str());
+
+    bt.CopyTo(file);
+    file.MessageEnd();
+}
+
+void load_key(const std::string& filename, CryptoPP::BufferedTransformation& bt)
+{
+    CryptoPP::FileSource file(filename.c_str(), true);
+
+    file.TransferTo(bt);
+    bt.MessageEnd();
+}
+
+vanetza::security::ecdsa256::KeyPair to_keypair(const vanetza::security::BackendCryptoPP::PrivateKey& private_key)
+{
+    vanetza::security::ecdsa256::KeyPair kp;
+
+    auto& private_exponent = private_key.GetPrivateExponent();
+    private_exponent.Encode(kp.private_key.key.data(), kp.private_key.key.size());
+
+    vanetza::security::BackendCryptoPP::PublicKey public_key;
+    private_key.MakePublicKey(public_key);
+
+    auto& public_element = public_key.GetPublicElement();
+    public_element.x.Encode(kp.public_key.x.data(), kp.public_key.x.size());
+    public_element.y.Encode(kp.public_key.y.data(), kp.public_key.y.size());
+
+    return kp;
+}

--- a/tools/certify/keyio.hpp
+++ b/tools/certify/keyio.hpp
@@ -1,0 +1,15 @@
+#ifndef CERTIFY_KEYIO_HPP
+#define CERTIFY_KEYIO_HPP
+
+#include <cryptopp/cryptlib.h>
+#include <string>
+#include <vanetza/security/backend_cryptopp.hpp>
+#include <vanetza/security/ecdsa256.hpp>
+
+void save_key(const std::string&, const CryptoPP::BufferedTransformation&);
+
+void load_key(const std::string&, CryptoPP::BufferedTransformation&);
+
+vanetza::security::ecdsa256::KeyPair to_keypair(const vanetza::security::BackendCryptoPP::PrivateKey&);
+
+#endif /* CERTIFY_KEYIO_HPP */

--- a/tools/certify/main.cpp
+++ b/tools/certify/main.cpp
@@ -1,0 +1,16 @@
+#include "options.hpp"
+#include <boost/program_options.hpp>
+#include <iostream>
+
+// using namespace vanetza;
+
+int main(int argc, const char** argv)
+{
+    try {
+        std::unique_ptr<Command> command = parse_options(argc, argv);
+        return command->execute();
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/tools/certify/options.cpp
+++ b/tools/certify/options.cpp
@@ -1,0 +1,66 @@
+#include "commands/genkey.hpp"
+#include "commands/root-ca.hpp"
+#include "commands/auth-ca.hpp"
+#include "commands/sign-ticket.hpp"
+#include "options.hpp"
+#include <boost/program_options.hpp>
+#include <iostream>
+#include <memory>
+
+namespace po = boost::program_options;
+
+std::unique_ptr<Command> parse_options(int argc, const char *argv[])
+{
+    po::options_description global("global options");
+    global.add_options()
+        ("command", po::value<std::string>(), "Command to execute.")
+        ("subargs", po::value<std::vector<std::string>>(), "Arguments for command.")
+    ;
+
+    po::positional_options_description pos;
+    pos.add("command", 1);
+    pos.add("subargs", -1);
+
+    po::variables_map vm;
+
+    po::parsed_options parsed = po::command_line_parser(argc, argv)
+        .options(global)
+        .positional(pos)
+        .allow_unregistered()
+        .run();
+
+    po::store(parsed, vm);
+    po::notify(vm);
+
+    if (!vm.count("command")) {
+        std::cout << "Available commands: genkey" << std::endl;
+
+        throw po::invalid_option_value("");
+    }
+
+    std::string cmd = vm["command"].as<std::string>();
+
+    std::vector<std::string> opts = po::collect_unrecognized(parsed.options, po::include_positional);
+    opts.erase(opts.begin());
+
+    std::unique_ptr<Command> command;
+
+    if (cmd == "genkey") {
+        command.reset(new GenkeyCommand());
+    } else if (cmd == "root-ca") {
+        command.reset(new RootCaCommand());
+    } else if (cmd == "auth-ca") {
+        command.reset(new AuthCaCommand());
+    } else if (cmd == "sign-ticket") {
+        command.reset(new SignTicketCommand());
+    }
+
+    if (command) {
+        command->parse(opts);
+
+        return command;
+    }
+
+    // unrecognized command
+    throw po::invalid_option_value(cmd);
+}

--- a/tools/certify/options.hpp
+++ b/tools/certify/options.hpp
@@ -1,0 +1,10 @@
+#ifndef CERTIFY_OPTIONS_HPP
+#define CERTIFY_OPTIONS_HPP
+
+#include "command.hpp"
+#include <boost/variant/variant.hpp>
+#include <boost/variant/get.hpp>
+
+std::unique_ptr<Command> parse_options(int argc, const char *argv[]);
+
+#endif /* CERTIFY_OPTIONS_HPP */

--- a/tools/certify/options.hpp
+++ b/tools/certify/options.hpp
@@ -2,8 +2,7 @@
 #define CERTIFY_OPTIONS_HPP
 
 #include "command.hpp"
-#include <boost/variant/variant.hpp>
-#include <boost/variant/get.hpp>
+#include <memory>
 
 std::unique_ptr<Command> parse_options(int argc, const char *argv[]);
 


### PR DESCRIPTION
Certify allows creating keys and certificates from the command line for later use in applications.

A follow-up commit will add support for these certificates in a new certificate manager.

This is an initial version. Command names and options can probably be improved as well as some parts of the certification process can be extracted info functions.

I'm creating this PR, so comments can be added.