### PR TITLE
Add basic chain validation

### DIFF
--- a/tools/socktap/hello_application.cpp
+++ b/tools/socktap/hello_application.cpp
@@ -22,7 +22,7 @@ void HelloApplication::indicate(const DataIndication& indication, UpPacketPtr pa
 
 void HelloApplication::schedule_timer()
 {
-    timer_.expires_from_now(std::chrono::seconds(2));
+    timer_.expires_from_now(std::chrono::milliseconds(800));
     timer_.async_wait(std::bind(&HelloApplication::on_timer, this, std::placeholders::_1));
 }
 

--- a/tools/socktap/main.cpp
+++ b/tools/socktap/main.cpp
@@ -171,7 +171,8 @@ int main(int argc, const char** argv)
             mib.itsGnSecurity = false;
         }
 
-        security::SignService sign_service = straight_sign_service(trigger.runtime(), *certificate_provider, *crypto_backend);
+        security::SignPreparer sign_preparer(trigger.runtime().now());
+        security::SignService sign_service = straight_sign_service(trigger.runtime(), *certificate_provider, *crypto_backend, sign_preparer);
         security::VerifyService verify_service = straight_verify_service(trigger.runtime(), *certificate_validator, *crypto_backend, cert_cache);
 
         GpsPositionProvider positioning(vm["gpsd-host"].as<std::string>(), vm["gpsd-port"].as<std::string>());

--- a/tools/socktap/main.cpp
+++ b/tools/socktap/main.cpp
@@ -171,8 +171,8 @@ int main(int argc, const char** argv)
             mib.itsGnSecurity = false;
         }
 
-        security::SignPreparer sign_preparer(trigger.runtime().now());
-        security::SignService sign_service = straight_sign_service(trigger.runtime(), *certificate_provider, *crypto_backend, sign_preparer);
+        security::SignHeaderPolicy sign_header_policy(trigger.runtime().now());
+        security::SignService sign_service = straight_sign_service(*certificate_provider, *crypto_backend, sign_header_policy);
         security::VerifyService verify_service = straight_verify_service(trigger.runtime(), *certificate_validator, *crypto_backend, cert_cache);
 
         GpsPositionProvider positioning(vm["gpsd-host"].as<std::string>(), vm["gpsd-port"].as<std::string>());

--- a/tools/socktap/main.cpp
+++ b/tools/socktap/main.cpp
@@ -133,6 +133,8 @@ int main(int argc, const char** argv)
             mib.itsGnSecurity = false;
         } else if (security_option == "naive") {
             mib.itsGnSecurity = true;
+            trust_store = new vanetza::security::TrustStore(trusted_roots);
+            certificate_validator = std::unique_ptr<vanetza::security::CertificateValidator> { new vanetza::security::DefaultCertificateValidator(trigger.runtime().now(), *trust_store, cert_cache) };
         } else if (security_option == "null") {
             mib.itsGnSecurity = true;
             certificate_provider = std::unique_ptr<vanetza::security::CertificateProvider> { new vanetza::security::NullCertificateProvider() };
@@ -173,7 +175,7 @@ int main(int argc, const char** argv)
 
         security::SignHeaderPolicy sign_header_policy(trigger.runtime().now());
         security::SignService sign_service = straight_sign_service(*certificate_provider, *crypto_backend, sign_header_policy);
-        security::VerifyService verify_service = straight_verify_service(trigger.runtime(), *certificate_validator, *crypto_backend, cert_cache);
+        security::VerifyService verify_service = straight_verify_service(trigger.runtime(), *certificate_provider, *certificate_validator, *crypto_backend, cert_cache, sign_header_policy);
 
         GpsPositionProvider positioning(vm["gpsd-host"].as<std::string>(), vm["gpsd-port"].as<std::string>());
         security::SecurityEntity security_entity(sign_service, verify_service);

--- a/vanetza/geonet/tests/router_indicate.cpp
+++ b/vanetza/geonet/tests/router_indicate.cpp
@@ -158,7 +158,7 @@ TEST_F(RouterIndicate, shb_secured_equal_payload)
     router.indicate(std::move(packet_up), mac_address_sender, mac_address_destination);
 
     // check hook, it shouldn't have been called
-    EXPECT_FALSE(test_and_reset_packet_drop());
+    EXPECT_FALSE(test_and_reset_packet_drop()) << "Packet drop reason: " << static_cast<int>(drop_reason);
 
     // check if packet was not discarded
     ASSERT_NE(nullptr, ind_ifc.m_last_packet.get());
@@ -316,4 +316,3 @@ TEST_F(RouterIndicate, shb_secured_hook_hop_limit)
     // check if packet was dropped
     EXPECT_EQ(nullptr, ind_ifc.m_last_packet.get());
 }
-

--- a/vanetza/geonet/tests/router_indicate.cpp
+++ b/vanetza/geonet/tests/router_indicate.cpp
@@ -11,7 +11,7 @@ class RouterIndicate : public ::testing::Test
 {
 public:
     RouterIndicate() :
-        security(runtime), router(runtime, mib), packet_drop_occurred(false) {}
+        runtime(Clock::at("2010-12-23 18:29")), security(runtime), router(runtime, mib), packet_drop_occurred(false) {}
 
 protected:
     virtual void SetUp() override

--- a/vanetza/geonet/tests/router_request.cpp
+++ b/vanetza/geonet/tests/router_request.cpp
@@ -184,12 +184,13 @@ TEST_F(RouterRequest, shb_repetition)
     EXPECT_EQ(DataConfirm::ResultCode::ACCEPTED, confirm.result_code);
     EXPECT_EQ(1, req_ifc.m_requests);
     ASSERT_TRUE(!!req_ifc.m_last_packet);
-    const auto packet_size = size(*req_ifc.m_last_packet, OsiLayer::Network, OsiLayer::Application);
+    // length of network layer is excluded because of varying secured message header fields
+    const auto payload_size = size(*req_ifc.m_last_packet, OsiLayer::Transport, OsiLayer::Application);
 
     // trigger five repetitions
     for (unsigned i = 0; i < 5; ++i) {
         runtime.trigger(std::chrono::milliseconds(100));
     }
     EXPECT_EQ(6, req_ifc.m_requests);
-    EXPECT_EQ(packet_size, size(*req_ifc.m_last_packet, OsiLayer::Network, OsiLayer::Application));
+    EXPECT_EQ(payload_size, size(*req_ifc.m_last_packet, OsiLayer::Transport, OsiLayer::Application));
 }

--- a/vanetza/geonet/tests/security_context.hpp
+++ b/vanetza/geonet/tests/security_context.hpp
@@ -3,6 +3,7 @@
 
 #include <vanetza/common/runtime.hpp>
 #include <vanetza/security/backend.hpp>
+#include <vanetza/security/certificate_cache.hpp>
 #include <vanetza/security/default_certificate_validator.hpp>
 #include <vanetza/security/naive_certificate_provider.hpp>
 #include <vanetza/security/security_entity.hpp>
@@ -19,10 +20,11 @@ public:
         certificate_provider(new security::NaiveCertificateProvider(rt.now())),
         roots({ certificate_provider->root_certificate() }),
         trust_store(roots),
-        certificate_validator(new security::DefaultCertificateValidator(rt.now(), trust_store)),
+        cert_cache(rt.now()),
+        certificate_validator(new security::DefaultCertificateValidator(rt.now(), trust_store, cert_cache)),
         security(
             straight_sign_service(rt, *certificate_provider, *backend),
-            straight_verify_service(rt, *certificate_validator, *backend))
+            straight_verify_service(rt, *certificate_validator, *backend, cert_cache))
     {
     }
 
@@ -36,6 +38,7 @@ private:
     std::unique_ptr<security::NaiveCertificateProvider> certificate_provider;
     std::vector<security::Certificate> roots;
     security::TrustStore trust_store;
+    security::CertificateCache cert_cache;
     std::unique_ptr<security::CertificateValidator> certificate_validator;
     security::SecurityEntity security;
 };

--- a/vanetza/geonet/tests/security_context.hpp
+++ b/vanetza/geonet/tests/security_context.hpp
@@ -27,6 +27,9 @@ public:
             straight_sign_service(rt, *certificate_provider, *backend, sign_preparer),
             straight_verify_service(rt, *certificate_validator, *backend, cert_cache))
     {
+        for (auto cert : certificate_provider->own_chain()) {
+            cert_cache.put(cert);
+        }
     }
 
     security::SecurityEntity& entity()

--- a/vanetza/geonet/tests/security_context.hpp
+++ b/vanetza/geonet/tests/security_context.hpp
@@ -22,8 +22,9 @@ public:
         trust_store(roots),
         cert_cache(rt.now()),
         certificate_validator(new security::DefaultCertificateValidator(rt.now(), trust_store, cert_cache)),
+        sign_preparer(rt.now()),
         security(
-            straight_sign_service(rt, *certificate_provider, *backend),
+            straight_sign_service(rt, *certificate_provider, *backend, sign_preparer),
             straight_verify_service(rt, *certificate_validator, *backend, cert_cache))
     {
     }
@@ -40,6 +41,7 @@ private:
     security::TrustStore trust_store;
     security::CertificateCache cert_cache;
     std::unique_ptr<security::CertificateValidator> certificate_validator;
+    security::SignPreparer sign_preparer;
     security::SecurityEntity security;
 };
 

--- a/vanetza/geonet/tests/security_context.hpp
+++ b/vanetza/geonet/tests/security_context.hpp
@@ -22,9 +22,9 @@ public:
         trust_store(roots),
         cert_cache(rt.now()),
         certificate_validator(new security::DefaultCertificateValidator(rt.now(), trust_store, cert_cache)),
-        sign_preparer(rt.now()),
+        sign_header_policy(rt.now()),
         security(
-            straight_sign_service(rt, *certificate_provider, *backend, sign_preparer),
+            straight_sign_service(*certificate_provider, *backend, sign_header_policy),
             straight_verify_service(rt, *certificate_validator, *backend, cert_cache))
     {
         for (auto cert : certificate_provider->own_chain()) {
@@ -44,7 +44,7 @@ private:
     security::TrustStore trust_store;
     security::CertificateCache cert_cache;
     std::unique_ptr<security::CertificateValidator> certificate_validator;
-    security::SignPreparer sign_preparer;
+    security::SignHeaderPolicy sign_header_policy;
     security::SecurityEntity security;
 };
 

--- a/vanetza/geonet/tests/security_context.hpp
+++ b/vanetza/geonet/tests/security_context.hpp
@@ -25,7 +25,7 @@ public:
         sign_header_policy(rt.now()),
         security(
             straight_sign_service(*certificate_provider, *backend, sign_header_policy),
-            straight_verify_service(rt, *certificate_validator, *backend, cert_cache))
+            straight_verify_service(rt, *certificate_provider, *certificate_validator, *backend, cert_cache, sign_header_policy))
     {
         for (auto cert : certificate_provider->own_chain()) {
             cert_cache.put(cert);

--- a/vanetza/security/CMakeLists.txt
+++ b/vanetza/security/CMakeLists.txt
@@ -3,6 +3,7 @@ add_vanetza_component(security
     backend_null.cpp
     basic_elements.cpp
     certificate.cpp
+    certificate_cache.cpp
     default_certificate_validator.cpp
     ecc_point.cpp
     ecdsa256.cpp

--- a/vanetza/security/certificate.hpp
+++ b/vanetza/security/certificate.hpp
@@ -49,7 +49,7 @@ public:
      * Create CertificateValidity signalling an invalid certificate
      * \param reason Reason for invalidity
      */
-    CertificateValidity(CertificateInvalidReason reason) : m_reason(reason) {}
+    CertificateValidity(CertificateInvalidReason reason, Certificate invalid_certificate) : m_reason(reason), m_invalid_certificate(invalid_certificate) {}
 
     /**
      * \brief Create CertificateValidity signalling a valid certificate
@@ -72,8 +72,17 @@ public:
      */
     CertificateInvalidReason reason() const { return *m_reason; }
 
+    /**
+     * \brief Get certificate that failed the validation
+     * This call is only safe if the certificate is available, i.e. check validity before!
+     *
+     * \return invalid certificate
+     */
+    Certificate invalid_certificate() const { return *m_invalid_certificate; }
+
 private:
     boost::optional<CertificateInvalidReason> m_reason;
+    boost::optional<Certificate> m_invalid_certificate;
 };
 
 /**

--- a/vanetza/security/certificate_cache.cpp
+++ b/vanetza/security/certificate_cache.cpp
@@ -44,13 +44,12 @@ std::list<Certificate> CertificateCache::lookup(HashedId8 id)
     for (auto item = range.first; item != range.second; ++item) {
         matches.push_back(item->second.certificate);
 
+        // renew cache entry, see CertificateCache::put()
         auto subject_type = item->second.certificate.subject_info.subject_type;
 
         if (subject_type == SubjectType::Authorization_Ticket) {
-            // see CertificateCache::put()
             item->second.evict_time = time_now + std::chrono::seconds(2);
         } else if (subject_type == SubjectType::Authorization_Authority) {
-            // see CertificateCache::put()
             item->second.evict_time = time_now + std::chrono::seconds(3600);
         }
     }

--- a/vanetza/security/certificate_cache.cpp
+++ b/vanetza/security/certificate_cache.cpp
@@ -1,0 +1,83 @@
+#include <vanetza/security/certificate_cache.hpp>
+
+namespace vanetza
+{
+namespace security
+{
+
+CertificateCache::CertificateCache(const Clock::time_point& time_now): time_now(time_now) { }
+
+void CertificateCache::put(Certificate certificate)
+{
+    evict_entries();
+
+    HashedId8 id = calculate_hash(certificate);
+
+    CacheEntry entry;
+    entry.certificate = certificate;
+
+    if (certificate.subject_info.subject_type == SubjectType::Authorization_Ticket) {
+        // section 7.1 in ETSI TS 103 097 v1.2.1
+        // there must be a CAM with the authorization ticket every one second
+        // we choose two seconds here to account for one missed message
+        entry.evict_time = time_now + std::chrono::seconds(2);
+    } else if (certificate.subject_info.subject_type == SubjectType::Authorization_Authority) {
+        // section 7.1 in ETSI TS 103 097 v1.2.1
+        // chains are only sent upon request, there will probably only be a few authoritation authorities in use
+        // one hour is an arbitrarily choosen cache period for now
+        entry.evict_time = time_now + std::chrono::seconds(3600);
+    } else {
+        // shouldn't happen, we ignore other certificates
+        return;
+    }
+
+    certificates.insert(std::make_pair(id, entry));
+}
+
+std::list<Certificate> CertificateCache::lookup(HashedId8 id)
+{
+    using iterator = std::multimap<HashedId8, CacheEntry>::iterator;
+    std::pair<iterator, iterator> range = certificates.equal_range(id);
+
+    std::list<Certificate> matches;
+
+    for (auto item = range.first; item != range.second; ++item) {
+        matches.push_back(item->second.certificate);
+
+        auto subject_type = item->second.certificate.subject_info.subject_type;
+
+        if (subject_type == SubjectType::Authorization_Ticket) {
+            // see CertificateCache::put()
+            item->second.evict_time = time_now + std::chrono::seconds(2);
+        } else if (subject_type == SubjectType::Authorization_Authority) {
+            // see CertificateCache::put()
+            item->second.evict_time = time_now + std::chrono::seconds(3600);
+        }
+    }
+
+    // evict after lookup, so we don't evict items we need just now
+    evict_entries();
+
+    return matches;
+}
+
+void CertificateCache::evict_entries()
+{
+    // TODO: Optimize performance. Currently it scans all entries on each access.
+
+    using iterator = std::multimap<HashedId8, CacheEntry>::const_iterator;
+    std::pair<iterator, iterator> range;
+
+    for (auto i = certificates.begin(); i != certificates.end(); i++) {
+        range = certificates.equal_range(i->first);
+
+        for (auto x = range.first; x != range.second; ++x) {
+            if (x->second.evict_time < time_now) {
+                certificates.erase(x);
+            }
+        }
+    }
+}
+
+} // namespace security
+} // namespace vanetza

--- a/vanetza/security/certificate_cache.cpp
+++ b/vanetza/security/certificate_cache.cpp
@@ -15,8 +15,17 @@ void CertificateCache::put(Certificate certificate)
 
     std::list<Certificate> certs = lookup(id);
 
+    // TODO: This is probably horribly inefficient, find most efficient but still correct comparison
     if (certs.size()) {
-        return; // TODO: only ignore if exact duplicate
+        auto binary_cert = convert_for_signing(certificate);
+
+        for (auto& cert : certs) {
+            auto binary = convert_for_signing(cert);
+
+            if (binary == binary_cert) {
+                return;
+            }
+        }
     }
 
     CacheEntry entry;

--- a/vanetza/security/certificate_cache.hpp
+++ b/vanetza/security/certificate_cache.hpp
@@ -1,0 +1,50 @@
+#ifndef VANETZA_CERTIFICATE_CACHE_HPP
+#define VANETZA_CERTIFICATE_CACHE_HPP
+
+#include <map>
+#include <list>
+#include <vanetza/common/clock.hpp>
+#include <vanetza/security/certificate.hpp>
+
+namespace vanetza
+{
+namespace security
+{
+
+struct CacheEntry
+{
+    Certificate certificate;
+    Clock::time_point evict_time;
+};
+
+class CertificateCache
+{
+public:
+    CertificateCache(const Clock::time_point& time_now);
+
+    /**
+     * Puts a certificate into the cache.
+     *
+     * \param certificate certificate to add to the cache
+     */
+    void put(Certificate certificate);
+
+    /**
+     * Lookup certificates based on the passed HashedId8.
+     *
+     * \param id hash identifier of the certificate
+     * \return all stored certificates matching the passed identifier
+     */
+    std::list<Certificate> lookup(HashedId8 id);
+
+private:
+    const Clock::time_point& time_now;
+    std::multimap<HashedId8, CacheEntry> certificates;
+
+    void evict_entries();
+};
+
+} // namespace security
+} // namespace vanetza
+
+#endif /* VANETZA_CERTIFICATE_CACHE_HPP */

--- a/vanetza/security/certificate_provider.hpp
+++ b/vanetza/security/certificate_provider.hpp
@@ -19,6 +19,12 @@ public:
     virtual const Certificate& own_certificate() = 0;
 
     /**
+     * Get own certificate chain, excluding the leaf certificate and root CA
+     * \return own certificate chain
+     */
+    virtual const std::list<Certificate> own_chain() = 0;
+
+    /**
      * Get private key associated with own certificate
      * \return private key
      */

--- a/vanetza/security/decap_confirm.hpp
+++ b/vanetza/security/decap_confirm.hpp
@@ -2,6 +2,7 @@
 #define DECAP_CONFIRM_HPP
 
 #include <vanetza/security/certificate.hpp>
+#include <vanetza/security/decap_confirm.hpp>
 #include <vanetza/security/payload.hpp>
 #include <boost/optional.hpp>
 #include <cstdint>

--- a/vanetza/security/decap_confirm.hpp
+++ b/vanetza/security/decap_confirm.hpp
@@ -45,7 +45,7 @@ struct DecapConfirm
     PacketVariant plaintext_payload; // mandatory
     DecapReport report; // mandatory
     CertificateValidity certificate_validity; // non-standard extension
-    boost::optional<uint64_t> certificate_id; // optional
+    boost::optional<HashedId8> certificate_id; // optional
     // member field 'permissions' currently not used; optional
 };
 

--- a/vanetza/security/default_certificate_validator.cpp
+++ b/vanetza/security/default_certificate_validator.cpp
@@ -87,7 +87,7 @@ CertificateValidity DefaultCertificateValidator::check_certificate(const Certifi
     }
 
     HashedId8 signer_hash = boost::get<HashedId8>(certificate.signer_info);
-    std::vector<Certificate> possible_signers = m_trust_store.find_by_id(signer_hash);
+    std::list<Certificate> possible_signers = m_trust_store.lookup(signer_hash);
 
     // try to extract ECDSA signature
     boost::optional<EcdsaSignature> sig = extract_ecdsa_signature(certificate.signature);

--- a/vanetza/security/default_certificate_validator.cpp
+++ b/vanetza/security/default_certificate_validator.cpp
@@ -7,7 +7,6 @@
 #include <vanetza/security/signature.hpp>
 #include <vanetza/security/trust_store.hpp>
 #include <chrono>
-#include <iostream>
 
 namespace vanetza
 {

--- a/vanetza/security/default_certificate_validator.cpp
+++ b/vanetza/security/default_certificate_validator.cpp
@@ -7,6 +7,7 @@
 #include <vanetza/security/signature.hpp>
 #include <vanetza/security/trust_store.hpp>
 #include <chrono>
+#include <iostream>
 
 namespace vanetza
 {
@@ -101,9 +102,9 @@ CertificateValidity DefaultCertificateValidator::check_certificate(const Certifi
     // create buffer of certificate
     ByteBuffer cert = convert_for_signing(certificate);
 
-    std::list<Certificate> possible_signers = m_trust_store.lookup(signer_hash);
+    const std::list<Certificate> possible_trusted_signers = m_trust_store.lookup(signer_hash);
 
-    for (auto& possible_signer : possible_signers) {
+    for (auto& possible_signer : possible_trusted_signers) {
         auto verification_key = get_public_key(possible_signer);
 
         // this should never happen, as the verify service already ensures a key is present
@@ -116,7 +117,7 @@ CertificateValidity DefaultCertificateValidator::check_certificate(const Certifi
         }
     }
 
-    possible_signers = m_cert_cache.lookup(signer_hash);
+    const std::list<Certificate> possible_signers = m_cert_cache.lookup(signer_hash);
 
     for (auto& possible_signer : possible_signers) {
         auto verification_key = get_public_key(possible_signer);

--- a/vanetza/security/default_certificate_validator.hpp
+++ b/vanetza/security/default_certificate_validator.hpp
@@ -12,6 +12,7 @@ namespace security
 
 // forward declaration
 class TrustStore;
+class CertificateCache;
 
 /**
  * \brief A simplistic certificate validator
@@ -21,7 +22,7 @@ class TrustStore;
 class DefaultCertificateValidator : public CertificateValidator
 {
 public:
-    DefaultCertificateValidator(const Clock::time_point& time_now, const TrustStore& trust_store);
+    DefaultCertificateValidator(const Clock::time_point& time_now, const TrustStore& trust_store, CertificateCache& cert_cache);
 
     /**
      * Check validity of given certificate.
@@ -35,6 +36,7 @@ private:
     std::unique_ptr<Backend> m_crypto_backend;
     const Clock::time_point& m_time_now;
     const TrustStore& m_trust_store;
+    CertificateCache& m_cert_cache;
 };
 
 } // namespace security

--- a/vanetza/security/default_certificate_validator.hpp
+++ b/vanetza/security/default_certificate_validator.hpp
@@ -24,9 +24,10 @@ public:
     DefaultCertificateValidator(const Clock::time_point& time_now, const TrustStore& trust_store);
 
     /**
-     * \brief check certificate
-     * \param certificate to verify
-     * \return certificate status
+     * Check validity of given certificate.
+     *
+     * \param certificate given certificate
+     * \return validity result
      */
     CertificateValidity check_certificate(const Certificate& certificate) override;
 

--- a/vanetza/security/naive_certificate_provider.cpp
+++ b/vanetza/security/naive_certificate_provider.cpp
@@ -31,6 +31,11 @@ const Certificate& NaiveCertificateProvider::own_certificate()
     return m_own_certificate;
 }
 
+const std::list<Certificate> NaiveCertificateProvider::own_chain()
+{
+    return std::list<Certificate>();
+}
+
 const ecdsa256::PrivateKey& NaiveCertificateProvider::own_private_key()
 {
     return m_own_key_pair.private_key;

--- a/vanetza/security/naive_certificate_provider.cpp
+++ b/vanetza/security/naive_certificate_provider.cpp
@@ -33,7 +33,9 @@ const Certificate& NaiveCertificateProvider::own_certificate()
 
 const std::list<Certificate> NaiveCertificateProvider::own_chain()
 {
-    return std::list<Certificate>();
+    static const std::list<Certificate> chain = { aa_certificate() };
+
+    return chain;
 }
 
 const ecdsa256::PrivateKey& NaiveCertificateProvider::own_private_key()
@@ -41,11 +43,26 @@ const ecdsa256::PrivateKey& NaiveCertificateProvider::own_private_key()
     return m_own_key_pair.private_key;
 }
 
+const ecdsa256::KeyPair& NaiveCertificateProvider::aa_key_pair()
+{
+    static const ecdsa256::KeyPair aa_key_pair = m_crypto_backend.generate_key_pair();
+
+    return aa_key_pair;
+}
+
 const ecdsa256::KeyPair& NaiveCertificateProvider::root_key_pair()
 {
     static const ecdsa256::KeyPair root_key_pair = m_crypto_backend.generate_key_pair();
 
     return root_key_pair;
+}
+
+const Certificate& NaiveCertificateProvider::aa_certificate()
+{
+    static const std::string aa_subject("Naive Authorization CA");
+    static const Certificate aa_certificate = generate_aa_certificate(aa_subject);
+
+    return aa_certificate;
 }
 
 const Certificate& NaiveCertificateProvider::root_certificate()
@@ -62,7 +79,7 @@ Certificate NaiveCertificateProvider::generate_authorization_ticket()
     Certificate certificate;
 
     // section 6.1 in TS 103 097 v1.2.1
-    certificate.signer_info = calculate_hash(root_certificate());
+    certificate.signer_info = calculate_hash(aa_certificate());
 
     // section 6.3 in TS 103 097 v1.2.1
     certificate.subject_info.subject_type = SubjectType::Authorization_Ticket;
@@ -93,12 +110,57 @@ Certificate NaiveCertificateProvider::generate_authorization_ticket()
 
     // set signature
     ByteBuffer data_buffer = convert_for_signing(certificate);
+    certificate.signature = m_crypto_backend.sign_data(aa_key_pair().private_key, data_buffer);
+
+    return certificate;
+}
+
+Certificate NaiveCertificateProvider::generate_aa_certificate(const std::string& subject_name)
+{
+    // create certificate
+    Certificate certificate;
+
+    // section 6.1 in TS 103 097 v1.2.1
+    certificate.signer_info = calculate_hash(root_certificate());
+
+    // section 6.3 in TS 103 097 v1.2.1
+    certificate.subject_info.subject_type = SubjectType::Authorization_Authority;
+
+    // section 7.4.2 in TS 103 097 v1.2.1
+    std::vector<unsigned char> subject(subject_name.begin(), subject_name.end());
+    certificate.subject_info.subject_name = subject;
+
+    // section 6.6 in TS 103 097 v1.2.1 - levels currently undefined
+    certificate.subject_attributes.push_back(SubjectAssurance(0x00));
+
+    // section 7.4.1 in TS 103 097 v1.2.1
+    // set subject attributes
+    // set the verification_key
+    Uncompressed coordinates;
+    coordinates.x.assign(aa_key_pair().public_key.x.begin(), aa_key_pair().public_key.x.end());
+    coordinates.y.assign(aa_key_pair().public_key.y.begin(), aa_key_pair().public_key.y.end());
+    EccPoint ecc_point = coordinates;
+    ecdsa_nistp256_with_sha256 ecdsa;
+    ecdsa.public_key = ecc_point;
+    VerificationKey verification_key;
+    verification_key.key = ecdsa;
+    certificate.subject_attributes.push_back(verification_key);
+
+    // section 6.7 in TS 103 097 v1.2.1
+    // set validity restriction
+    StartAndEndValidity start_and_end;
+    start_and_end.start_validity = convert_time32(m_time_now - std::chrono::hours(1));
+    start_and_end.end_validity = convert_time32(m_time_now + std::chrono::hours(23));
+    certificate.validity_restriction.push_back(start_and_end);
+
+    // set signature
+    ByteBuffer data_buffer = convert_for_signing(certificate);
     certificate.signature = m_crypto_backend.sign_data(root_key_pair().private_key, data_buffer);
 
     return certificate;
 }
 
-Certificate NaiveCertificateProvider::generate_root_certificate(const std::string& root_subject)
+Certificate NaiveCertificateProvider::generate_root_certificate(const std::string& subject_name)
 {
     // create certificate
     Certificate certificate;
@@ -110,7 +172,7 @@ Certificate NaiveCertificateProvider::generate_root_certificate(const std::strin
     certificate.subject_info.subject_type = SubjectType::Root_Ca;
 
     // section 7.4.2 in TS 103 097 v1.2.1
-    std::vector<unsigned char> subject(root_subject.begin(), root_subject.end());
+    std::vector<unsigned char> subject(subject_name.begin(), subject_name.end());
     certificate.subject_info.subject_name = subject;
 
     // section 6.6 in TS 103 097 v1.2.1 - levels currently undefined

--- a/vanetza/security/naive_certificate_provider.hpp
+++ b/vanetza/security/naive_certificate_provider.hpp
@@ -43,7 +43,7 @@ public:
     const ecdsa256::PrivateKey& own_private_key() override;
 
     /**
-     * \brief get signer certificate (same for all instances)
+     * \brief get root certificate (same for all instances)
      * \return signing root certificate
      */
     const Certificate& root_certificate();
@@ -53,7 +53,19 @@ private:
      * \brief get root key (same for all instances)
      * \return root key
      */
+    const ecdsa256::KeyPair& aa_key_pair();
+
+    /**
+     * \brief get root key (same for all instances)
+     * \return root key
+     */
     const ecdsa256::KeyPair& root_key_pair();
+
+    /**
+     * \brief get ticket signer certificate (same for all instances)
+     * \return signing authorization authoirity certificate
+     */
+    const Certificate& aa_certificate();
 
     /**
      * \brief generate a authorization ticket
@@ -63,11 +75,18 @@ private:
     Certificate generate_authorization_ticket();
 
     /**
+     * \brief generate a authorization authoirity certificate
+     *
+     * \return generated certificate
+     */
+    Certificate generate_aa_certificate(const std::string& subject_name);
+
+    /**
      * \brief generate a root certificate
      *
      * \return generated certificate
      */
-    Certificate generate_root_certificate(const std::string& root_subject);
+    Certificate generate_root_certificate(const std::string& subject_name);
 
     BackendCryptoPP m_crypto_backend; /*< key generation is not a generic backend feature */
     const Clock::time_point& m_time_now;

--- a/vanetza/security/naive_certificate_provider.hpp
+++ b/vanetza/security/naive_certificate_provider.hpp
@@ -31,6 +31,12 @@ public:
     const Certificate& own_certificate() override;
 
     /**
+     * Get own certificate chain, excluding the leaf certificate and root CA
+     * \return own certificate chain
+     */
+    const std::list<Certificate> own_chain();
+
+    /**
      * \brief get own private key
      * \return private key
      */

--- a/vanetza/security/null_certificate_provider.cpp
+++ b/vanetza/security/null_certificate_provider.cpp
@@ -47,6 +47,11 @@ const Certificate& NullCertificateProvider::own_certificate()
     return null_certificate();
 }
 
+const std::list<Certificate> NullCertificateProvider::own_chain()
+{
+    return std::list<Certificate>();
+}
+
 const ecdsa256::PrivateKey& NullCertificateProvider::own_private_key()
 {
     static const ecdsa256::PrivateKey null_key {};

--- a/vanetza/security/null_certificate_provider.hpp
+++ b/vanetza/security/null_certificate_provider.hpp
@@ -14,6 +14,7 @@ public:
     NullCertificateProvider();
 
     const Certificate& own_certificate() override;
+    const std::list<Certificate> own_chain() override;
     const ecdsa256::PrivateKey& own_private_key() override;
 
     /**

--- a/vanetza/security/null_certificate_validator.cpp
+++ b/vanetza/security/null_certificate_validator.cpp
@@ -5,18 +5,18 @@ namespace vanetza
 namespace security
 {
 
-NullCertificateValidator::NullCertificateValidator() : m_check_result(CertificateInvalidReason::UNKNOWN_SIGNER)
+NullCertificateValidator::NullCertificateValidator() : m_reason(CertificateInvalidReason::UNKNOWN_SIGNER)
 {
 }
 
-CertificateValidity NullCertificateValidator::check_certificate(const Certificate&)
+CertificateValidity NullCertificateValidator::check_certificate(const Certificate& certificate)
 {
-    return m_check_result;
+    return CertificateValidity(m_reason, certificate);
 }
 
-void NullCertificateValidator::certificate_check_result(const CertificateValidity& result)
+void NullCertificateValidator::certificate_check_result(const CertificateInvalidReason reason)
 {
-    m_check_result = result;
+    m_reason = reason;
 }
 
 } // namespace security

--- a/vanetza/security/null_certificate_validator.hpp
+++ b/vanetza/security/null_certificate_validator.hpp
@@ -13,16 +13,16 @@ class NullCertificateValidator : public CertificateValidator
 public:
     NullCertificateValidator();
 
-    CertificateValidity check_certificate(const Certificate&) override;
+    CertificateValidity check_certificate(const Certificate& certificate) override;
 
     /**
      * Set predefined result of check_certificate() calls
      * \param result predefined result
      */
-    void certificate_check_result(const CertificateValidity& result);
+    void certificate_check_result(const CertificateInvalidReason reason);
 
 private:
-    CertificateValidity m_check_result;
+    CertificateInvalidReason m_reason;
 };
 
 } // namespace security

--- a/vanetza/security/security_entity.cpp
+++ b/vanetza/security/security_entity.cpp
@@ -31,16 +31,19 @@ EncapConfirm SecurityEntity::encapsulate_packet(EncapRequest&& encap_request)
     SignConfirm sign_confirm = m_sign_service(std::move(sign_request));
     EncapConfirm encap_confirm;
     encap_confirm.sec_packet = std::move(sign_confirm.secured_message);
+
     return encap_confirm;
 }
 
 DecapConfirm SecurityEntity::decapsulate_packet(DecapRequest&& decap_request)
 {
     VerifyConfirm verify_confirm = m_verify_service(VerifyRequest { decap_request.sec_packet });
+
     DecapConfirm decap_confirm;
     decap_confirm.plaintext_payload = std::move(decap_request.sec_packet.payload.data);
     decap_confirm.report = static_cast<DecapReport>(verify_confirm.report);
     decap_confirm.certificate_validity = verify_confirm.certificate_validity;
+
     return decap_confirm;
 }
 

--- a/vanetza/security/sign_service.cpp
+++ b/vanetza/security/sign_service.cpp
@@ -31,7 +31,7 @@ Signature signature_placeholder()
 
 
 SignHeaderPolicy::SignHeaderPolicy(const Clock::time_point& time_now) :
-    m_time_now(time_now), m_cam_next_certificate(time_now) { }
+    m_time_now(time_now), m_cam_next_certificate(time_now), m_cert_requested(false), m_chain_requested(false) { }
 
 std::list<HeaderField> SignHeaderPolicy::prepare_header(const SignRequest& request, CertificateProvider& certificate_provider)
 {
@@ -42,18 +42,50 @@ std::list<HeaderField> SignHeaderPolicy::prepare_header(const SignRequest& reque
 
     if (request.its_aid == itsAidCa) {
         // section 7.1 in TS 103 097 v1.2.1
-        if (m_time_now < m_cam_next_certificate) {
+        if (m_chain_requested) {
+            std::list<Certificate> full_chain;
+            full_chain.push_back(certificate_provider.own_certificate());
+            for (auto chain_cert : certificate_provider.own_chain()) {
+                full_chain.push_back(chain_cert);
+            }
+            header_fields.push_back(SignerInfo { full_chain });
+            m_cam_next_certificate = m_time_now + std::chrono::seconds(1);
+        } else if (m_time_now < m_cam_next_certificate && !m_cert_requested) {
             header_fields.push_back(SignerInfo { calculate_hash(certificate_provider.own_certificate()) });
         } else {
             header_fields.push_back(SignerInfo { certificate_provider.own_certificate() });
             m_cam_next_certificate = m_time_now + std::chrono::seconds(1);
         }
+
+        if (m_unknown_certificates.size() > 0) {
+            std::list<HashedId3> unknown_certificates;
+            unknown_certificates.splice(unknown_certificates.end(), m_unknown_certificates);
+            header_fields.push_back(unknown_certificates);
+        }
+
+        m_cert_requested = false;
+        m_chain_requested = false;
     } else {
         // TODO: Add generation location
         header_fields.push_back(SignerInfo { certificate_provider.own_certificate() });
     }
 
     return header_fields;
+}
+
+void SignHeaderPolicy::report_unknown_certificate(HashedId8 id)
+{
+    m_unknown_certificates.push_back(truncate(id));
+}
+
+void SignHeaderPolicy::report_requested_certificate()
+{
+    m_cert_requested = true;
+}
+
+void SignHeaderPolicy::report_requested_certificate_chain()
+{
+    m_chain_requested = true;
 }
 
 SignService straight_sign_service(CertificateProvider& certificate_provider, Backend& backend, SignHeaderPolicy& sign_header_policy)

--- a/vanetza/security/sign_service.hpp
+++ b/vanetza/security/sign_service.hpp
@@ -35,6 +35,17 @@ struct SignConfirm
     SecuredMessage secured_message;
 };
 
+class SignPreparer
+{
+public:
+    SignPreparer(const Clock::time_point& time_now);
+
+    SignConfirm prepare_sign_confirm(SignRequest& request, const Certificate& certificate, Clock::time_point now);
+
+private:
+    Clock::time_point m_time_next_certificate;
+};
+
 /**
  * Equivalant of SN-SIGN service in TS 102 723-8 v1.1.1
  */
@@ -45,18 +56,20 @@ using SignService = std::function<SignConfirm(SignRequest&&)>;
  * \param rt runtime
  * \param cert certificate provider
  * \param backend cryptographic backend
+ * \param sign_preparer sign preparer
  * \return callable sign service
  */
-SignService straight_sign_service(Runtime&, CertificateProvider&, Backend&);
+SignService straight_sign_service(Runtime&, CertificateProvider&, Backend&, SignPreparer&);
 
 /**
  * SignService deferring actually signature calculation using EcdsaSignatureFuture
  * \param rt runtime
  * \param cert certificate provider
  * \param backend cryptographic backend
+ * \param sign_preparer sign preparer
  * \return callable sign service
  */
-SignService deferred_sign_service(Runtime&, CertificateProvider&, Backend&);
+SignService deferred_sign_service(Runtime&, CertificateProvider&, Backend&, SignPreparer&);
 
 /**
  * SignService without real cryptography but dummy signature

--- a/vanetza/security/sign_service.hpp
+++ b/vanetza/security/sign_service.hpp
@@ -35,15 +35,16 @@ struct SignConfirm
     SecuredMessage secured_message;
 };
 
-class SignPreparer
+class SignHeaderPolicy
 {
 public:
-    SignPreparer(const Clock::time_point& time_now);
+    SignHeaderPolicy(const Clock::time_point& time_now);
 
-    SignConfirm prepare_sign_confirm(SignRequest& request, const Certificate& certificate, Clock::time_point now);
+    std::list<HeaderField> prepare_header(const SignRequest& request, CertificateProvider& certificate_provider);
 
 private:
-    Clock::time_point m_time_next_certificate;
+    const Clock::time_point& m_time_now;
+    Clock::time_point m_cam_next_certificate;
 };
 
 /**
@@ -56,20 +57,20 @@ using SignService = std::function<SignConfirm(SignRequest&&)>;
  * \param rt runtime
  * \param cert certificate provider
  * \param backend cryptographic backend
- * \param sign_preparer sign preparer
+ * \param sign_header_policy sign header policy
  * \return callable sign service
  */
-SignService straight_sign_service(Runtime&, CertificateProvider&, Backend&, SignPreparer&);
+SignService straight_sign_service(CertificateProvider&, Backend&, SignHeaderPolicy&);
 
 /**
  * SignService deferring actually signature calculation using EcdsaSignatureFuture
  * \param rt runtime
  * \param cert certificate provider
  * \param backend cryptographic backend
- * \param sign_preparer sign preparer
+ * \param sign_header_policy sign header policy
  * \return callable sign service
  */
-SignService deferred_sign_service(Runtime&, CertificateProvider&, Backend&, SignPreparer&);
+SignService deferred_sign_service(CertificateProvider&, Backend&, SignHeaderPolicy&);
 
 /**
  * SignService without real cryptography but dummy signature

--- a/vanetza/security/sign_service.hpp
+++ b/vanetza/security/sign_service.hpp
@@ -42,9 +42,18 @@ public:
 
     std::list<HeaderField> prepare_header(const SignRequest& request, CertificateProvider& certificate_provider);
 
+    void report_unknown_certificate(HashedId8 id);
+
+    void report_requested_certificate();
+
+    void report_requested_certificate_chain();
+
 private:
     const Clock::time_point& m_time_now;
     Clock::time_point m_cam_next_certificate;
+    std::list<HashedId3> m_unknown_certificates;
+    bool m_cert_requested;
+    bool m_chain_requested;
 };
 
 /**

--- a/vanetza/security/static_certificate_provider.cpp
+++ b/vanetza/security/static_certificate_provider.cpp
@@ -5,12 +5,12 @@ namespace vanetza
 namespace security
 {
 
-StaticCertificateProvider::StaticCertificateProvider(const Certificate& authorization_ticket, const ecdsa256::KeyPair& authorization_ticket_key) :
+StaticCertificateProvider::StaticCertificateProvider(const Certificate& authorization_ticket, const ecdsa256::PrivateKey& authorization_ticket_key) :
     authorization_ticket(authorization_ticket), authorization_ticket_key(authorization_ticket_key) { }
 
 const ecdsa256::PrivateKey& StaticCertificateProvider::own_private_key()
 {
-    return authorization_ticket_key.private_key;
+    return authorization_ticket_key;
 }
 
 const Certificate& StaticCertificateProvider::own_certificate()

--- a/vanetza/security/static_certificate_provider.cpp
+++ b/vanetza/security/static_certificate_provider.cpp
@@ -5,12 +5,17 @@ namespace vanetza
 namespace security
 {
 
-StaticCertificateProvider::StaticCertificateProvider(const Certificate& authorization_ticket, const ecdsa256::PrivateKey& authorization_ticket_key) :
-    authorization_ticket(authorization_ticket), authorization_ticket_key(authorization_ticket_key) { }
+StaticCertificateProvider::StaticCertificateProvider(const Certificate authorization_ticket, const ecdsa256::PrivateKey authorization_ticket_key, std::list<Certificate> chain) :
+    authorization_ticket(authorization_ticket), authorization_ticket_key(authorization_ticket_key), chain(chain) { }
 
 const ecdsa256::PrivateKey& StaticCertificateProvider::own_private_key()
 {
     return authorization_ticket_key;
+}
+
+const std::list<Certificate> StaticCertificateProvider::own_chain()
+{
+    return chain;
 }
 
 const Certificate& StaticCertificateProvider::own_certificate()

--- a/vanetza/security/static_certificate_provider.hpp
+++ b/vanetza/security/static_certificate_provider.hpp
@@ -16,13 +16,19 @@ namespace security
 class StaticCertificateProvider : public CertificateProvider
 {
 public:
-    StaticCertificateProvider(const Certificate& authorization_ticket, const ecdsa256::PrivateKey& authorization_ticket_key);
+    StaticCertificateProvider(const Certificate authorization_ticket, const ecdsa256::PrivateKey authorization_ticket_key, std::list<Certificate> chain = std::list<Certificate>());
 
     /**
      * Get own certificate to use for signing
      * \return own certificate
      */
     virtual const Certificate& own_certificate() override;
+
+    /**
+     * Get own certificate chain, excluding the leaf certificate and root CA
+     * \return own certificate chain
+     */
+    virtual const std::list<Certificate> own_chain() override;
 
     /**
      * Get private key associated with own certificate
@@ -32,6 +38,7 @@ public:
 
 private:
     Certificate authorization_ticket;
+    std::list<Certificate> chain;
     ecdsa256::PrivateKey authorization_ticket_key;
 };
 

--- a/vanetza/security/static_certificate_provider.hpp
+++ b/vanetza/security/static_certificate_provider.hpp
@@ -16,7 +16,7 @@ namespace security
 class StaticCertificateProvider : public CertificateProvider
 {
 public:
-    StaticCertificateProvider(const Certificate& authorization_ticket, const ecdsa256::KeyPair& authorization_ticket_key);
+    StaticCertificateProvider(const Certificate& authorization_ticket, const ecdsa256::PrivateKey& authorization_ticket_key);
 
     /**
      * Get own certificate to use for signing
@@ -32,7 +32,7 @@ public:
 
 private:
     Certificate authorization_ticket;
-    ecdsa256::KeyPair authorization_ticket_key;
+    ecdsa256::PrivateKey authorization_ticket_key;
 };
 
 } // namespace security

--- a/vanetza/security/tests/CMakeLists.txt
+++ b/vanetza/security/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(security_test
 configure_gtest_directory(SOURCES $<TARGET_OBJECTS:security_test> LINK_LIBRARIES Boost::boost security)
 
 add_gtest(Certificate certificate.cpp)
+add_gtest(CertificateCache certificate_cache.cpp)
 add_gtest(DefaultCertificateValidator default_certificate_validator.cpp)
 add_gtest(EccPoint ecc_point.cpp)
 add_gtest(EncryptionParameter encryption_parameter.cpp)

--- a/vanetza/security/tests/certificate_cache.cpp
+++ b/vanetza/security/tests/certificate_cache.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+#include <vanetza/security/certificate.hpp>
+#include <vanetza/security/certificate_cache.hpp>
+#include <vanetza/security/tests/serialization.hpp>
+
+using namespace vanetza;
+using namespace vanetza::security;
+
+TEST(CertificateCacheTest, lookup)
+{
+    const char str[] =
+        "02015388DEC640C6E19E010052000004B27D4D442F58E065F8D500478929BC843940F3C34D46C547"
+        "5803C03594E35BD7E0132FD01634E86D4F50F7F2366988E12525232D00D03E98FC21CA8E5D0AF370"
+        "02E0210B24030100002504010000000B0114E9DB83154CBC0203000000553C8D2B8A4E53F3D84A88"
+        "37BEEBE83D5C7F68484AC5EFCEEFCC7B0BC5E9531754AAF58BF90790A10F2FD11796A85E13DFFAAC"
+        "6073D2068465DA733994CD0C71";
+
+    Clock::time_point now = Clock::at("2016-08-01 00:00");
+    CertificateCache cache(now);
+    Certificate cert;
+
+    deserialize_from_hexstring(str, cert);
+
+    // empty cache
+    EXPECT_EQ(0, cache.lookup(calculate_hash(cert)).size());
+
+    cache.put(cert);
+
+    // cache only contains 'cert' and must be able to find it
+    EXPECT_EQ(1, cache.lookup(calculate_hash(cert)).size());
+
+    // expiration time is two seconds
+    now += std::chrono::seconds(3);
+
+    // required, as eviction happens after lookup
+    EXPECT_EQ(0, cache.lookup(HashedId8({ 0, 0, 0, 0, 0, 0, 0, 0 })).size());
+
+    // previous lookup should have cleared 'cert'
+    EXPECT_EQ(0, cache.lookup(calculate_hash(cert)).size());
+}

--- a/vanetza/security/tests/default_certificate_validator.cpp
+++ b/vanetza/security/tests/default_certificate_validator.cpp
@@ -1,4 +1,5 @@
 #include <vanetza/common/clock.hpp>
+#include <vanetza/security/certificate_cache.hpp>
 #include <vanetza/security/default_certificate_validator.hpp>
 #include <vanetza/security/naive_certificate_provider.hpp>
 #include <vanetza/security/trust_store.hpp>
@@ -16,7 +17,8 @@ public:
         cert_provider(time_now),
         roots({ cert_provider.root_certificate() }),
         trust_store(roots),
-        cert_validator(time_now, trust_store)
+        cert_cache(time_now),
+        cert_validator(time_now, trust_store, cert_cache)
     {
     }
 
@@ -25,6 +27,7 @@ protected:
     NaiveCertificateProvider cert_provider;
     std::vector<Certificate> roots;
     TrustStore trust_store;
+    CertificateCache cert_cache;
     DefaultCertificateValidator cert_validator;
 };
 

--- a/vanetza/security/tests/security_entity.cpp
+++ b/vanetza/security/tests/security_entity.cpp
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
 #include <vanetza/common/runtime.hpp>
 #include <vanetza/security/backend.hpp>
+#include <vanetza/security/certificate_cache.hpp>
 #include <vanetza/security/default_certificate_validator.hpp>
 #include <vanetza/security/naive_certificate_provider.hpp>
 #include <vanetza/security/security_entity.hpp>
+#include <vanetza/security/static_certificate_provider.hpp>
 #include <vanetza/security/trust_store.hpp>
 #include <vanetza/security/tests/check_payload.hpp>
 #include <vanetza/security/tests/check_signature.hpp>
@@ -19,9 +21,10 @@ protected:
         certificate_provider(new NaiveCertificateProvider(runtime.now())),
         roots({ certificate_provider->root_certificate() }),
         trust_store(roots),
-        certificate_validator(new DefaultCertificateValidator(runtime.now(), trust_store)),
+        cert_cache(runtime.now()),
+        certificate_validator(new DefaultCertificateValidator(runtime.now(), trust_store, cert_cache)),
         sign_service(straight_sign_service(runtime, *certificate_provider, *crypto_backend)),
-        verify_service(straight_verify_service(runtime, *certificate_validator, *crypto_backend)),
+        verify_service(straight_verify_service(runtime, *certificate_validator, *crypto_backend, cert_cache)),
         security(sign_service, verify_service)
     {
     }
@@ -46,11 +49,25 @@ protected:
         return confirm.sec_packet;
     }
 
+    SecuredMessage create_secured_message(Certificate& modified_certificate)
+    {
+        // we need to sign with the modified certificate, otherwise validation just fails because of a wrong signature
+        StaticCertificateProvider local_cert_provider(modified_certificate, certificate_provider.get()->own_private_key());
+        SignService local_sign_service(straight_sign_service(runtime, local_cert_provider, *crypto_backend));
+        SecurityEntity local_security(local_sign_service, verify_service);
+
+        EncapConfirm confirm = local_security.encapsulate_packet(create_encap_request());
+        auto secured_message = confirm.sec_packet;
+
+        return secured_message;
+    }
+
     Runtime runtime;
     std::unique_ptr<Backend> crypto_backend;
     std::unique_ptr<NaiveCertificateProvider> certificate_provider;
     std::vector<Certificate> roots;
     TrustStore trust_store;
+    CertificateCache cert_cache;
     std::unique_ptr<CertificateValidator> certificate_validator;
     SignService sign_service;
     VerifyService verify_service;
@@ -61,7 +78,7 @@ protected:
 TEST_F(SecurityEntityTest, mutual_acceptance)
 {
     SignService sign = straight_sign_service(runtime, *certificate_provider, *crypto_backend);
-    VerifyService verify = straight_verify_service(runtime, *certificate_validator, *crypto_backend);
+    VerifyService verify = straight_verify_service(runtime, *certificate_validator, *crypto_backend, cert_cache);
     SecurityEntity other_security(sign, verify);
     EncapConfirm encap_confirm = other_security.encapsulate_packet(create_encap_request());
     DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { encap_confirm.sec_packet });
@@ -167,68 +184,44 @@ TEST_F(SecurityEntityTest, verify_message_modified_message_type)
 
 TEST_F(SecurityEntityTest, verify_message_modified_certificate_name)
 {
-    // create decap request
-    auto secured_message = create_secured_message();
-    DecapRequest decap_request(secured_message);
-
     // change the subject name
-    SignerInfo* signer_info = secured_message.header_field<HeaderFieldType::Signer_Info>();
-    ASSERT_TRUE(signer_info);
-    Certificate& certificate = boost::get<Certificate>(*signer_info);
+    Certificate certificate = certificate_provider.get()->own_certificate();
     certificate.subject_info.subject_name = {42};
 
     // verify message
-    DecapConfirm decap_confirm = security.decapsulate_packet(std::move(decap_request));
+    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { create_secured_message(certificate) });
     ASSERT_FALSE(decap_confirm.certificate_validity);
     EXPECT_EQ(CertificateInvalidReason::INVALID_NAME, decap_confirm.certificate_validity.reason());
 }
 
 TEST_F(SecurityEntityTest, verify_message_modified_certificate_signer_info)
 {
-    // create decap request
-    auto secured_message = create_secured_message();
-    DecapRequest decap_request(secured_message);
-
     // change the subject info
-    SignerInfo* signer_info = secured_message.header_field<HeaderFieldType::Signer_Info>();
-    ASSERT_TRUE(signer_info);
-    Certificate& certificate = boost::get<Certificate>(*signer_info);
+    Certificate certificate = certificate_provider.get()->own_certificate();
     HashedId8 faulty_hash {{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 }};
     certificate.signer_info = faulty_hash;
 
     // verify message
-    DecapConfirm decap_confirm = security.decapsulate_packet(std::move(decap_request));
+    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { create_secured_message(certificate) });
     ASSERT_FALSE(decap_confirm.certificate_validity);
     EXPECT_EQ(CertificateInvalidReason::UNKNOWN_SIGNER, decap_confirm.certificate_validity.reason());
 }
 
 TEST_F(SecurityEntityTest, verify_message_modified_certificate_subject_info)
 {
-    // create decap request
-    auto secured_message = create_secured_message();
-    DecapRequest decap_request(secured_message);
-
     // change the subject info
-    SignerInfo* signer_info = secured_message.header_field<HeaderFieldType::Signer_Info>();
-    ASSERT_TRUE(signer_info);
-    Certificate& certificate = boost::get<Certificate>(*signer_info);
+    Certificate certificate = certificate_provider.get()->own_certificate();
     certificate.subject_info.subject_type = SubjectType::Root_Ca;
 
     // verify message
-    DecapConfirm decap_confirm = security.decapsulate_packet(std::move(decap_request));
+    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { create_secured_message(certificate) });
     ASSERT_FALSE(decap_confirm.certificate_validity);
     EXPECT_EQ(CertificateInvalidReason::UNKNOWN_SIGNER, decap_confirm.certificate_validity.reason());
 }
 
 TEST_F(SecurityEntityTest, verify_message_modified_certificate_subject_assurance)
 {
-    // create decap request
-    auto secured_message = create_secured_message();
-    DecapRequest decap_request(secured_message);
-
-    SignerInfo* signer_info = secured_message.header_field<HeaderFieldType::Signer_Info>();
-    ASSERT_TRUE(signer_info);
-    Certificate& certificate = boost::get<Certificate>(*signer_info);
+    Certificate certificate = certificate_provider.get()->own_certificate();
     for (auto& subject_attribute : certificate.subject_attributes) {
         if (SubjectAttributeType::Assurance_Level == get_type(subject_attribute)) {
             SubjectAssurance& subject_assurance = boost::get<SubjectAssurance>(subject_attribute);
@@ -238,29 +231,24 @@ TEST_F(SecurityEntityTest, verify_message_modified_certificate_subject_assurance
     }
 
     // verify message
-    DecapConfirm decap_confirm = security.decapsulate_packet(std::move(decap_request));
+    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { create_secured_message(certificate) });
     ASSERT_FALSE(decap_confirm.certificate_validity);
     EXPECT_EQ(CertificateInvalidReason::UNKNOWN_SIGNER, decap_confirm.certificate_validity.reason());
 }
 
 TEST_F(SecurityEntityTest, verify_message_outdated_certificate)
 {
-    // prepare decap request
-    auto secured_message = create_secured_message();
-
     // forge certificate with outdatet validity
     StartAndEndValidity outdated_validity;
     outdated_validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
     outdated_validity.end_validity = convert_time32(runtime.now() - std::chrono::minutes(1));
-    auto signer_info_field = secured_message.header_field(HeaderFieldType::Signer_Info);
-    ASSERT_TRUE(signer_info_field);
-    auto certificate = boost::get<Certificate>(&boost::get<SignerInfo>(*signer_info_field));
-    ASSERT_TRUE(certificate);
-    certificate->validity_restriction.clear();
-    certificate->validity_restriction.push_back(outdated_validity);
+
+    Certificate certificate = certificate_provider.get()->own_certificate();
+    certificate.validity_restriction.clear();
+    certificate.validity_restriction.push_back(outdated_validity);
 
     // verify message
-    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { secured_message });
+    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { create_secured_message(certificate) });
     EXPECT_EQ(DecapReport::Invalid_Certificate, decap_confirm.report);
     ASSERT_FALSE(decap_confirm.certificate_validity);
     EXPECT_EQ(CertificateInvalidReason::OFF_TIME_PERIOD, decap_confirm.certificate_validity.reason());
@@ -268,22 +256,17 @@ TEST_F(SecurityEntityTest, verify_message_outdated_certificate)
 
 TEST_F(SecurityEntityTest, verify_message_premature_certificate)
 {
-    // prepare decap request
-    auto secured_message = create_secured_message();
-
     // forge certificate with premature validity
     StartAndEndValidity premature_validity;
     premature_validity.start_validity = convert_time32(runtime.now() + std::chrono::hours(1));
     premature_validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(25));
-    auto signer_info_field = secured_message.header_field(HeaderFieldType::Signer_Info);
-    ASSERT_TRUE(signer_info_field);
-    auto certificate = boost::get<Certificate>(&boost::get<SignerInfo>(*signer_info_field));
-    ASSERT_TRUE(certificate);
-    certificate->validity_restriction.clear();
-    certificate->validity_restriction.push_back(premature_validity);
+
+    Certificate certificate = certificate_provider.get()->own_certificate();
+    certificate.validity_restriction.clear();
+    certificate.validity_restriction.push_back(premature_validity);
 
     // verify message
-    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { secured_message });
+    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { create_secured_message(certificate) });
     EXPECT_EQ(DecapReport::Invalid_Certificate, decap_confirm.report);
     ASSERT_FALSE(decap_confirm.certificate_validity);
     EXPECT_EQ(CertificateInvalidReason::OFF_TIME_PERIOD, decap_confirm.certificate_validity.reason());
@@ -291,13 +274,7 @@ TEST_F(SecurityEntityTest, verify_message_premature_certificate)
 
 TEST_F(SecurityEntityTest, verify_message_modified_certificate_validity_restriction)
 {
-    // prepare decap request
-    auto secured_message = create_secured_message();
-    DecapRequest decap_request(secured_message);
-
-    SignerInfo* signer_info = secured_message.header_field<HeaderFieldType::Signer_Info>();
-    ASSERT_TRUE(signer_info);
-    Certificate& certificate = boost::get<Certificate>(*signer_info);
+    Certificate certificate = certificate_provider.get()->own_certificate();
     for (auto& validity_restriction : certificate.validity_restriction) {
         ValidityRestrictionType type = get_type(validity_restriction);
         ASSERT_EQ(type, ValidityRestrictionType::Time_Start_And_End);
@@ -309,24 +286,18 @@ TEST_F(SecurityEntityTest, verify_message_modified_certificate_validity_restrict
     }
 
     // verify message
-    DecapConfirm decap_confirm = security.decapsulate_packet(std::move(decap_request));
+    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { create_secured_message(certificate) });
     ASSERT_FALSE(decap_confirm.certificate_validity);
     EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, decap_confirm.certificate_validity.reason());
 }
 
 TEST_F(SecurityEntityTest, verify_message_modified_certificate_signature)
 {
-    // prepare decap request
-    auto secured_message = create_secured_message();
-    DecapRequest decap_request(secured_message);
-
-    SignerInfo* signer_info = secured_message.header_field<HeaderFieldType::Signer_Info>();
-    ASSERT_TRUE(signer_info);
-    Certificate& certificate = boost::get<Certificate>(*signer_info);
+    Certificate certificate = certificate_provider.get()->own_certificate();
     certificate.signature = create_random_ecdsa_signature(0);
 
     // verify message
-    DecapConfirm decap_confirm = security.decapsulate_packet(std::move(decap_request));
+    DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { create_secured_message(certificate) });
     ASSERT_FALSE(decap_confirm.certificate_validity);
     EXPECT_EQ(CertificateInvalidReason::UNKNOWN_SIGNER, decap_confirm.certificate_validity.reason());
 }

--- a/vanetza/security/tests/security_entity.cpp
+++ b/vanetza/security/tests/security_entity.cpp
@@ -17,6 +17,7 @@ class SecurityEntityTest : public ::testing::Test
 {
 protected:
     SecurityEntityTest() :
+        runtime(Clock::at("2016-03-7 08:23")),
         crypto_backend(create_backend("default")),
         certificate_provider(new NaiveCertificateProvider(runtime.now())),
         roots({ certificate_provider->root_certificate() }),
@@ -27,13 +28,15 @@ protected:
         sign_service(straight_sign_service(runtime, *certificate_provider, *crypto_backend, sign_preparer)),
         verify_service(straight_verify_service(runtime, *certificate_validator, *crypto_backend, cert_cache)),
         security(sign_service, verify_service)
-    {
-    }
+    { }
 
     void SetUp() override
     {
-        runtime.reset(Clock::at("2016-03-7 08:23"));
         expected_payload[OsiLayer::Transport] = ByteBuffer {89, 27, 1, 4, 18, 85};
+
+        for (auto cert : certificate_provider->own_chain()) {
+            cert_cache.put(cert);
+        }
     }
 
     EncapRequest create_encap_request()

--- a/vanetza/security/tests/security_entity.cpp
+++ b/vanetza/security/tests/security_entity.cpp
@@ -188,7 +188,7 @@ TEST_F(SecurityEntityTest, verify_message_modified_message_type)
     // verify message
     DecapConfirm decap_confirm = security.decapsulate_packet(std::move(decap_request));
     // check if verify was successful
-    EXPECT_EQ(DecapReport::False_Signature, decap_confirm.report);
+    EXPECT_EQ(DecapReport::Signer_Certificate_Not_Found, decap_confirm.report);
 }
 
 TEST_F(SecurityEntityTest, verify_message_modified_certificate_name)
@@ -356,7 +356,7 @@ TEST_F(SecurityEntityTest, verify_message_modified_payload)
     // verify message
     DecapConfirm decap_confirm = security.decapsulate_packet(std::move(decap_request));
     // check if verify was successful
-    EXPECT_EQ(DecapReport::False_Signature, decap_confirm.report);
+    EXPECT_EQ(DecapReport::Signer_Certificate_Not_Found, decap_confirm.report);
 }
 
 TEST_F(SecurityEntityTest, verify_message_modified_generation_time_before_current_time)

--- a/vanetza/security/tests/security_entity.cpp
+++ b/vanetza/security/tests/security_entity.cpp
@@ -26,7 +26,7 @@ protected:
         certificate_validator(new DefaultCertificateValidator(runtime.now(), trust_store, cert_cache)),
         sign_header_policy(runtime.now()),
         sign_service(straight_sign_service(*certificate_provider, *crypto_backend, sign_header_policy)),
-        verify_service(straight_verify_service(runtime, *certificate_validator, *crypto_backend, cert_cache)),
+        verify_service(straight_verify_service(runtime, *certificate_provider, *certificate_validator, *crypto_backend, cert_cache, sign_header_policy)),
         security(sign_service, verify_service)
     { }
 
@@ -85,7 +85,7 @@ TEST_F(SecurityEntityTest, mutual_acceptance)
 {
     SignHeaderPolicy sign_header_policy(runtime.now());
     SignService sign = straight_sign_service(*certificate_provider, *crypto_backend, sign_header_policy);
-    VerifyService verify = straight_verify_service(runtime, *certificate_validator, *crypto_backend, cert_cache);
+    VerifyService verify = straight_verify_service(runtime, *certificate_provider, *certificate_validator, *crypto_backend, cert_cache, sign_header_policy);
     SecurityEntity other_security(sign, verify);
     EncapConfirm encap_confirm = other_security.encapsulate_packet(create_encap_request());
     DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { encap_confirm.sec_packet });
@@ -103,10 +103,10 @@ TEST_F(SecurityEntityTest, mutual_acceptance_impl)
     security::SignHeaderPolicy sign_header_policy_cryptopp(runtime.now());
     SecurityEntity cryptopp_security {
             straight_sign_service(*certificate_provider, *cryptopp_backend, sign_header_policy_openssl),
-            straight_verify_service(runtime, *certificate_validator, *cryptopp_backend, cert_cache) };
+            straight_verify_service(runtime, *certificate_provider, *certificate_validator, *cryptopp_backend, cert_cache, sign_header_policy_openssl) };
     SecurityEntity openssl_security {
             straight_sign_service(*certificate_provider, *openssl_backend, sign_header_policy_cryptopp),
-            straight_verify_service(runtime, *certificate_validator, *openssl_backend, cert_cache) };
+            straight_verify_service(runtime, *certificate_provider, *certificate_validator, *openssl_backend, cert_cache, sign_header_policy_cryptopp) };
 
     // OpenSSL to Crypto++
     EncapConfirm encap_confirm = openssl_security.encapsulate_packet(create_encap_request());

--- a/vanetza/security/tests/security_entity.cpp
+++ b/vanetza/security/tests/security_entity.cpp
@@ -103,10 +103,10 @@ TEST_F(SecurityEntityTest, mutual_acceptance_impl)
     security::SignHeaderPolicy sign_header_policy_cryptopp(runtime.now());
     SecurityEntity cryptopp_security {
             straight_sign_service(*certificate_provider, *cryptopp_backend, sign_header_policy_openssl),
-            straight_verify_service(runtime, *certificate_validator, *cryptopp_backend, sign_header_policy_cryptopp) };
+            straight_verify_service(runtime, *certificate_validator, *cryptopp_backend, cert_cache) };
     SecurityEntity openssl_security {
-            straight_sign_service(*certificate_provider, *openssl_backend),
-            straight_verify_service(runtime, *certificate_validator, *openssl_backend) };
+            straight_sign_service(*certificate_provider, *openssl_backend, sign_header_policy_cryptopp),
+            straight_verify_service(runtime, *certificate_validator, *openssl_backend, cert_cache) };
 
     // OpenSSL to Crypto++
     EncapConfirm encap_confirm = openssl_security.encapsulate_packet(create_encap_request());

--- a/vanetza/security/tests/trust_store.cpp
+++ b/vanetza/security/tests/trust_store.cpp
@@ -5,7 +5,7 @@
 
 using namespace vanetza::security;
 
-TEST(TrustStoreTest, find_by_id)
+TEST(TrustStoreTest, lookup)
 {
     const char str[] =
             "0200040C547275737465645F526F6F74808D000004F1817DD05116B855A853F80DB171A3A470D431"
@@ -24,13 +24,13 @@ TEST(TrustStoreTest, find_by_id)
     TrustStore trust_store(trusted_certificates);
 
     HashedId8 id;
-    std::vector<Certificate> matched_certificates;
+    std::list<Certificate> matches;
 
     id = HashedId8 { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    matched_certificates = trust_store.find_by_id(id);
-    EXPECT_EQ(0, matched_certificates.size());
+    matches = trust_store.lookup(id);
+    EXPECT_EQ(0, matches.size());
 
     id = calculate_hash(c);
-    matched_certificates = trust_store.find_by_id(id);
-    EXPECT_EQ(1, matched_certificates.size());
+    matches = trust_store.lookup(id);
+    EXPECT_EQ(1, matches.size());
 }

--- a/vanetza/security/trust_store.cpp
+++ b/vanetza/security/trust_store.cpp
@@ -13,18 +13,18 @@ TrustStore::TrustStore(const std::vector<Certificate>& trusted_certificates)
     }
 }
 
-std::vector<Certificate> TrustStore::find_by_id(HashedId8 id) const
+std::list<Certificate> TrustStore::lookup(HashedId8 id) const
 {
     using iterator = std::multimap<HashedId8, Certificate>::const_iterator;
     std::pair<iterator, iterator> range = certificates.equal_range(id);
 
-    std::vector<Certificate> matching_certificates;
+    std::list<Certificate> matches;
 
     for (auto item = range.first; item != range.second; ++item) {
-        matching_certificates.push_back(item->second);
+        matches.push_back(item->second);
     }
 
-    return matching_certificates;
+    return matches;
 }
 
 } // namespace security

--- a/vanetza/security/trust_store.hpp
+++ b/vanetza/security/trust_store.hpp
@@ -1,8 +1,9 @@
 #ifndef VANETZA_TRUST_STORE_HPP
 #define VANETZA_TRUST_STORE_HPP
 
-#include <vanetza/security/certificate.hpp>
+#include <list>
 #include <map>
+#include <vanetza/security/certificate.hpp>
 #include <vector>
 
 namespace vanetza
@@ -20,11 +21,12 @@ public:
     TrustStore(const std::vector<Certificate>& trusted_certificates);
 
     /**
-     * Look up certificates by hash id
-     * \param id hash identifier of certificate
-     * \return all stored certificates matching hash id
+     * Lookup certificates based on the passed HashedId8.
+     *
+     * \param id hash identifier of the certificate
+     * \return all stored certificates matching the passed identifier
      */
-    std::vector<Certificate> find_by_id(HashedId8 id) const;
+    std::list<Certificate> lookup(HashedId8 id) const;
 
 private:
     std::multimap<HashedId8, Certificate> certificates;

--- a/vanetza/security/verify_service.cpp
+++ b/vanetza/security/verify_service.cpp
@@ -1,9 +1,11 @@
 #include <vanetza/common/runtime.hpp>
 #include <vanetza/security/backend.hpp>
+#include <vanetza/security/certificate_cache.hpp>
 #include <vanetza/security/certificate_validator.hpp>
 #include <vanetza/security/its_aid.hpp>
 #include <vanetza/security/verify_service.hpp>
 #include <boost/optional.hpp>
+#include <iostream>
 #include <chrono>
 
 namespace vanetza
@@ -47,7 +49,7 @@ bool check_generation_time(Clock::time_point now, const SecuredMessageV2& messag
 
 } // namespace
 
-VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, Backend& backend)
+VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, Backend& backend, CertificateCache& cert_cache)
 {
     return [&](VerifyRequest&& request) -> VerifyConfirm {
         VerifyConfirm confirm;
@@ -67,18 +69,25 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
         confirm.its_aid = its_aid ? *its_aid : IntX(0);
 
         const SignerInfo* signer_info = secured_message.header_field<HeaderFieldType::Signer_Info>();
-        boost::optional<const Certificate&> certificate;
+        std::list<Certificate> possible_certificates;
         if (signer_info) {
             switch (get_type(*signer_info)) {
                 case SignerInfoType::Certificate:
-                    certificate = boost::get<Certificate>(*signer_info);
+                    possible_certificates.push_back(boost::get<Certificate>(*signer_info));
+                    break;
+                case SignerInfoType::Certificate_Digest_With_SHA256:
+                    possible_certificates.splice(possible_certificates.end(), cert_cache.lookup(boost::get<HashedId8>(*signer_info)));
                     break;
                 case SignerInfoType::Self:
-                case SignerInfoType::Certificate_Digest_With_SHA256:
                 case SignerInfoType::Certificate_Digest_With_Other_Algorithm:
                     break;
                 case SignerInfoType::Certificate_Chain:
-                    // TODO check if Certificate_Chain is inconsistant
+                    {
+                        std::list<Certificate> chain = boost::get<std::list<Certificate>>(*signer_info);
+                        if (chain.size() > 0) {
+                            possible_certificates.push_back(chain.front());
+                        }
+                    }
                     break;
                 default:
                     confirm.report = VerificationReport::Unsupported_Signer_Identifier_Type;
@@ -87,7 +96,7 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
             }
         }
 
-        if (!certificate) {
+        if (possible_certificates.size() == 0) {
             confirm.report = VerificationReport::Signer_Certificate_Not_Found;
             return confirm;
         }
@@ -99,16 +108,58 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
 
         // TODO check Duplicate_Message, Invalid_Mobility_Data, Unencrypted_Message, Decryption_Error
 
-        boost::optional<ecdsa256::PublicKey> public_key = get_public_key(certificate.get());
+        // check signature
+        const TrailerField* signature_field = secured_message.trailer_field(TrailerFieldType::Signature);
+        const Signature* signature = boost::get<Signature>(signature_field);
 
-        // public key could not be extracted
-        if (!public_key) {
-            confirm.report = VerificationReport::Invalid_Certificate;
+        if (!signature) {
+            confirm.report = VerificationReport::Unsigned_Message;
             return confirm;
         }
 
+        if (PublicKeyAlgorithm::Ecdsa_Nistp256_With_Sha256 != get_type(*signature)) {
+            confirm.report = VerificationReport::False_Signature;
+            return confirm;
+        }
+
+        // check the size of signature.R and siganture.s
+        auto ecdsa = extract_ecdsa_signature(*signature);
+        const auto field_len = field_size(PublicKeyAlgorithm::Ecdsa_Nistp256_With_Sha256);
+        if (!ecdsa || ecdsa->s.size() != field_len) {
+            confirm.report = VerificationReport::False_Signature;
+            return confirm;
+        }
+
+        // verify payload signature with given signature
+        ByteBuffer payload = convert_for_signing(secured_message, get_size(*signature_field));
+        boost::optional<Certificate> signer;
+
+        for (auto& cert : possible_certificates) {
+            boost::optional<ecdsa256::PublicKey> public_key = get_public_key(cert);
+
+            // public key could not be extracted
+            if (!public_key) {
+                confirm.report = VerificationReport::Invalid_Certificate;
+                return confirm;
+            }
+
+            if (backend.verify_data(public_key.get(), payload, *ecdsa)) {
+                signer = cert;
+                break;
+            }
+        }
+
+        if (!signer) {
+            // could also be a colliding HashedId8, but the probability is pretty low
+            confirm.report = VerificationReport::False_Signature;
+            confirm.certificate_validity = CertificateInvalidReason::UNKNOWN_SIGNER;
+            return confirm;
+        }
+
+        // TODO check if Certificate_Chain is inconsistant
+        CertificateValidity cert_validity = certs.check_certificate(signer.get());
+
         // if certificate could not be verified return correct DecapReport
-        CertificateValidity cert_validity = certs.check_certificate(*certificate);
         if (!cert_validity) {
             confirm.report = VerificationReport::Invalid_Certificate;
             confirm.certificate_validity = cert_validity;
@@ -117,29 +168,9 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
 
         // TODO check if Revoked_Certificate
 
-        // check Signature
-        const TrailerField* signature_field = secured_message.trailer_field(TrailerFieldType::Signature);
-        const Signature* signature = boost::get<Signature>(signature_field);
-        if (!signature) {
-            confirm.report = VerificationReport::Unsigned_Message;
-        } else if (PublicKeyAlgorithm::Ecdsa_Nistp256_With_Sha256 != get_type(*signature)) {
-            confirm.report = VerificationReport::False_Signature;
-        } else {
-            // check the size of signature.R and siganture.s
-            auto ecdsa = extract_ecdsa_signature(*signature);
-            const auto field_len = field_size(PublicKeyAlgorithm::Ecdsa_Nistp256_With_Sha256);
-            if (!ecdsa || ecdsa->s.size() != field_len) {
-                confirm.report = VerificationReport::False_Signature;
-            } else {
-                // verify payload signature with given signature
-                ByteBuffer payload = convert_for_signing(secured_message, get_size(*signature_field));
-                if (backend.verify_data(public_key.get(), payload, *ecdsa)) {
-                    confirm.report = VerificationReport::Success;
-                } else {
-                    confirm.report = VerificationReport::False_Signature;
-                }
-            }
-        }
+        cert_cache.put(signer.get());
+
+        confirm.report = VerificationReport::Success;
 
         return confirm;
     };

--- a/vanetza/security/verify_service.cpp
+++ b/vanetza/security/verify_service.cpp
@@ -1,10 +1,13 @@
 #include <vanetza/common/runtime.hpp>
 #include <vanetza/security/backend.hpp>
 #include <vanetza/security/certificate_cache.hpp>
+#include <vanetza/security/certificate_provider.hpp>
 #include <vanetza/security/certificate_validator.hpp>
 #include <vanetza/security/its_aid.hpp>
+#include <vanetza/security/sign_service.hpp>
 #include <vanetza/security/verify_service.hpp>
 #include <boost/optional.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <chrono>
 
 namespace vanetza
@@ -48,7 +51,7 @@ bool check_generation_time(Clock::time_point now, const SecuredMessageV2& messag
 
 } // namespace
 
-VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, Backend& backend, CertificateCache& cert_cache)
+VerifyService straight_verify_service(Runtime& rt, CertificateProvider& cert_provider, CertificateValidator& certs, Backend& backend, CertificateCache& cert_cache, SignHeaderPolicy& sign_policy)
 {
     return [&](VerifyRequest&& request) -> VerifyConfirm {
         VerifyConfirm confirm;
@@ -62,6 +65,21 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
         if (2 != secured_message.protocol_version()) {
             confirm.report = VerificationReport::Incompatible_Protocol;
             return confirm;
+        }
+
+        const std::list<HashedId3>* requested_certs = secured_message.header_field<HeaderFieldType::Request_Unrecognized_Certificate>();
+        if (requested_certs) {
+            for (auto& requested_cert : *requested_certs) {
+                if (truncate(calculate_hash(cert_provider.own_certificate())) == requested_cert) {
+                    sign_policy.report_requested_certificate();
+                }
+
+                for (auto& cert : cert_provider.own_chain()) {
+                    if (truncate(calculate_hash(cert)) == requested_cert) {
+                        sign_policy.report_requested_certificate_chain();
+                    }
+                }
+            }
         }
 
         const IntX* its_aid = secured_message.header_field<HeaderFieldType::Its_Aid>();
@@ -87,15 +105,24 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
                 case SignerInfoType::Certificate_Digest_With_Other_Algorithm:
                     break;
                 case SignerInfoType::Certificate_Chain:
-                    {
-                        std::list<Certificate> chain = boost::get<std::list<Certificate>>(*signer_info);
-                        if (chain.size() == 0) {
-                            confirm.report = VerificationReport::Signer_Certificate_Not_Found;
-                            return confirm;
-                        }
-                        signer_hash = calculate_hash(chain.front());
-                        possible_certificates.push_back(chain.front());
+                {
+                    std::list<Certificate> chain = boost::get<std::list<Certificate>>(*signer_info);
+                    if (chain.size() == 0) {
+                        confirm.report = VerificationReport::Signer_Certificate_Not_Found;
+                        return confirm;
                     }
+                    // pre-check chain certificates in reverse order, otherwise they're not available for the ticket check
+                    for (auto& cert : boost::adaptors::reverse(chain)) {
+                        if (cert.subject_info.subject_type == SubjectType::Authorization_Authority) {
+                            CertificateValidity validity = certs.check_certificate(cert);
+                            if (validity) {
+                                cert_cache.put(cert);
+                            }
+                        }
+                    }
+                    signer_hash = calculate_hash(chain.front());
+                    possible_certificates.push_back(chain.front());
+                }
                     break;
                 default:
                     confirm.report = VerificationReport::Unsupported_Signer_Identifier_Type;
@@ -107,6 +134,7 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
         if (possible_certificates.size() == 0) {
             confirm.report = VerificationReport::Signer_Certificate_Not_Found;
             confirm.certificate_id = signer_hash;
+            sign_policy.report_unknown_certificate(signer_hash);
             return confirm;
         }
 
@@ -162,6 +190,7 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
             // could be a colliding HashedId8, but the probability is pretty low
             confirm.report = VerificationReport::Signer_Certificate_Not_Found;
             confirm.certificate_id = signer_hash;
+            sign_policy.report_unknown_certificate(signer_hash);
             return confirm;
         }
 
@@ -174,7 +203,14 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
             confirm.certificate_validity = cert_validity;
 
             if (cert_validity.reason() == CertificateInvalidReason::UNKNOWN_SIGNER) {
-                confirm.certificate_id = calculate_hash(cert_validity.invalid_certificate());
+                const Certificate& invalid_cert = cert_validity.invalid_certificate();
+
+                if (get_type(invalid_cert.signer_info) == SignerInfoType::Certificate_Digest_With_SHA256) {
+                    HashedId8 signer_hash = boost::get<HashedId8>(invalid_cert.signer_info);
+
+                    confirm.certificate_id = signer_hash;
+                    sign_policy.report_unknown_certificate(*confirm.certificate_id);
+                }
             }
 
             return confirm;

--- a/vanetza/security/verify_service.cpp
+++ b/vanetza/security/verify_service.cpp
@@ -5,7 +5,6 @@
 #include <vanetza/security/its_aid.hpp>
 #include <vanetza/security/verify_service.hpp>
 #include <boost/optional.hpp>
-#include <iostream>
 #include <chrono>
 
 namespace vanetza

--- a/vanetza/security/verify_service.cpp
+++ b/vanetza/security/verify_service.cpp
@@ -69,13 +69,19 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
 
         const SignerInfo* signer_info = secured_message.header_field<HeaderFieldType::Signer_Info>();
         std::list<Certificate> possible_certificates;
+
+        // use a dummy hash for initialization
+        HashedId8 signer_hash = HashedId8({ 0, 0, 0, 0, 0, 0, 0, 0 });
+
         if (signer_info) {
             switch (get_type(*signer_info)) {
                 case SignerInfoType::Certificate:
                     possible_certificates.push_back(boost::get<Certificate>(*signer_info));
+                    signer_hash = calculate_hash(boost::get<Certificate>(*signer_info));
                     break;
                 case SignerInfoType::Certificate_Digest_With_SHA256:
-                    possible_certificates.splice(possible_certificates.end(), cert_cache.lookup(boost::get<HashedId8>(*signer_info)));
+                    signer_hash = boost::get<HashedId8>(*signer_info);
+                    possible_certificates.splice(possible_certificates.end(), cert_cache.lookup(signer_hash));
                     break;
                 case SignerInfoType::Self:
                 case SignerInfoType::Certificate_Digest_With_Other_Algorithm:
@@ -83,9 +89,12 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
                 case SignerInfoType::Certificate_Chain:
                     {
                         std::list<Certificate> chain = boost::get<std::list<Certificate>>(*signer_info);
-                        if (chain.size() > 0) {
-                            possible_certificates.push_back(chain.front());
+                        if (chain.size() == 0) {
+                            confirm.report = VerificationReport::Signer_Certificate_Not_Found;
+                            return confirm;
                         }
+                        signer_hash = calculate_hash(chain.front());
+                        possible_certificates.push_back(chain.front());
                     }
                     break;
                 default:
@@ -97,6 +106,7 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
 
         if (possible_certificates.size() == 0) {
             confirm.report = VerificationReport::Signer_Certificate_Not_Found;
+            confirm.certificate_id = signer_hash;
             return confirm;
         }
 
@@ -149,9 +159,9 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
         }
 
         if (!signer) {
-            // could also be a colliding HashedId8, but the probability is pretty low
-            confirm.report = VerificationReport::False_Signature;
-            confirm.certificate_validity = CertificateInvalidReason::UNKNOWN_SIGNER;
+            // could be a colliding HashedId8, but the probability is pretty low
+            confirm.report = VerificationReport::Signer_Certificate_Not_Found;
+            confirm.certificate_id = signer_hash;
             return confirm;
         }
 
@@ -162,6 +172,11 @@ VerifyService straight_verify_service(Runtime& rt, CertificateValidator& certs, 
         if (!cert_validity) {
             confirm.report = VerificationReport::Invalid_Certificate;
             confirm.certificate_validity = cert_validity;
+
+            if (cert_validity.reason() == CertificateInvalidReason::UNKNOWN_SIGNER) {
+                confirm.certificate_id = calculate_hash(cert_validity.invalid_certificate());
+            }
+
             return confirm;
         }
 

--- a/vanetza/security/verify_service.hpp
+++ b/vanetza/security/verify_service.hpp
@@ -1,6 +1,7 @@
 #ifndef VERIFY_SERVICE_HPP_BR4ISDBH
 #define VERIFY_SERVICE_HPP_BR4ISDBH
 
+#include <boost/optional.hpp>
 #include <vanetza/common/byte_buffer.hpp>
 #include <vanetza/security/certificate.hpp>
 #include <vanetza/security/its_aid.hpp>
@@ -51,6 +52,7 @@ struct VerifyConfirm
     IntX its_aid; // mandatory
     ByteBuffer permissions; // mandatory
     CertificateValidity certificate_validity; // non-standard extension
+    boost::optional<HashedId8> certificate_id; // optional
 };
 
 /**

--- a/vanetza/security/verify_service.hpp
+++ b/vanetza/security/verify_service.hpp
@@ -20,7 +20,9 @@ namespace security
 // forward declarations
 class Backend;
 class CertificateCache;
+class CertificateProvider;
 class CertificateValidator;
+class SignHeaderPolicy;
 
 enum class VerificationReport
 {
@@ -63,12 +65,14 @@ using VerifyService = std::function<VerifyConfirm(VerifyRequest&&)>;
 /**
  * Get verify service with basic certificate and signature checks
  * \param rt runtime
- * \param certs certificate validator
+ * \param certificate_provider certificate provider
+ * \param certificate_validator certificate validator
  * \param backend crypto backend
  * \param certificate_cache certificate cache
+ * \param sign_header_policy sign header policy to report unknown certificates
  * \return callable verify service
  */
-VerifyService straight_verify_service(Runtime&, CertificateValidator&, Backend&, CertificateCache&);
+VerifyService straight_verify_service(Runtime&, CertificateProvider&, CertificateValidator&, Backend&, CertificateCache&, SignHeaderPolicy&);
 
 /**
  * Get insecure dummy verify service without any checks

--- a/vanetza/security/verify_service.hpp
+++ b/vanetza/security/verify_service.hpp
@@ -18,6 +18,7 @@ namespace security
 
 // forward declarations
 class Backend;
+class CertificateCache;
 class CertificateValidator;
 
 enum class VerificationReport
@@ -62,9 +63,10 @@ using VerifyService = std::function<VerifyConfirm(VerifyRequest&&)>;
  * \param rt runtime
  * \param certs certificate validator
  * \param backend crypto backend
+ * \param certificate_cache certificate cache
  * \return callable verify service
  */
-VerifyService straight_verify_service(Runtime&, CertificateValidator&, Backend&);
+VerifyService straight_verify_service(Runtime&, CertificateValidator&, Backend&, CertificateCache&);
 
 /**
  * Get insecure dummy verify service without any checks


### PR DESCRIPTION
Support for caching chains has been added as well as validating chains constructed from cached entries.

There are currently no consistency checks implemented. Sending unrecognized certificate requests also isn't implemented, yet.

As part of the proper chain validation a few tests had to be adjusted. These relied on certificate validation happening before the message itself is checked. These use the modified certificate when signing now, so these messages don't end up returning a false signature error only.