### PR TITLE
common: Add parsing support for BTP-A

### DIFF
--- a/vanetza/btp/data_indication.cpp
+++ b/vanetza/btp/data_indication.cpp
@@ -11,6 +11,16 @@ DataIndication::DataIndication()
 {
 }
 
+DataIndication::DataIndication(const geonet::DataIndication& ind, const HeaderA& btp) :
+    source_port(btp.source_port),
+    destination_port(btp.destination_port),
+    destination(ind.destination),
+    source_position(ind.source_position),
+    traffic_class(ind.traffic_class),
+    remaining_packet_lifetime(ind.remaining_packet_lifetime)
+{
+}
+
 DataIndication::DataIndication(const geonet::DataIndication& ind, const HeaderB& btp) :
     destination_port(btp.destination_port),
     destination_port_info(btp.destination_port_info),
@@ -23,4 +33,3 @@ DataIndication::DataIndication(const geonet::DataIndication& ind, const HeaderB&
 
 } // namespace btp
 } // namespace vanetza
-

--- a/vanetza/btp/data_indication.hpp
+++ b/vanetza/btp/data_indication.hpp
@@ -19,6 +19,7 @@ namespace btp
 struct DataIndication
 {
     DataIndication();
+    DataIndication(const geonet::DataIndication&, const HeaderA&);
     DataIndication(const geonet::DataIndication&, const HeaderB&);
 
     boost::optional<port_type> source_port;
@@ -34,4 +35,3 @@ struct DataIndication
 } // namespace vanetza
 
 #endif /* DATA_INDICATION_HPP_5YZM172D */
-

--- a/vanetza/btp/data_request.hpp
+++ b/vanetza/btp/data_request.hpp
@@ -26,6 +26,15 @@ struct DataRequestGeoNetParams
     geonet::TrafficClass traffic_class;
 };
 
+struct DataRequestA
+{
+    DataRequestA();
+
+    decltype(HeaderA::destination_port) destination_port;
+    decltype(HeaderA::source_port) source_port;
+    DataRequestGeoNetParams gn;
+};
+
 struct DataRequestB
 {
     DataRequestB();
@@ -39,4 +48,3 @@ struct DataRequestB
 } // namespace vanetza
 
 #endif /* DATA_REQUEST_HPP_BSJC1VFV */
-

--- a/vanetza/btp/header.cpp
+++ b/vanetza/btp/header.cpp
@@ -12,6 +12,18 @@ using vanetza::deserialize;
 constexpr std::size_t HeaderA::length_bytes;
 constexpr std::size_t HeaderB::length_bytes;
 
+void serialize(OutputArchive& ar, const HeaderA& hdr)
+{
+    serialize(ar, hdr.destination_port);
+    serialize(ar, hdr.source_port);
+}
+
+void deserialize(InputArchive& ar, HeaderA& hdr)
+{
+    deserialize(ar, hdr.destination_port);
+    deserialize(ar, hdr.source_port);
+}
+
 void serialize(OutputArchive& ar, const HeaderB& hdr)
 {
     serialize(ar, hdr.destination_port);
@@ -26,4 +38,3 @@ void deserialize(InputArchive& ar, HeaderB& hdr)
 
 } // namespace btp
 } // namespace vanetza
-

--- a/vanetza/btp/header.hpp
+++ b/vanetza/btp/header.hpp
@@ -23,6 +23,9 @@ struct HeaderA
 
 static_assert(sizeof(HeaderA) == HeaderA::length_bytes, "Wrong size");
 
+void serialize(OutputArchive&, const HeaderA&);
+void deserialize(InputArchive&, HeaderA&);
+
 // non-interactive packet transport
 struct HeaderB
 {
@@ -41,4 +44,3 @@ void deserialize(InputArchive&, HeaderB&);
 } // namespace vanetza
 
 #endif /* HEADER_HPP_FNKGEM7C */
-

--- a/vanetza/btp/header_conversion.hpp
+++ b/vanetza/btp/header_conversion.hpp
@@ -11,6 +11,20 @@ namespace convertible
 {
 
 template<>
+struct byte_buffer_impl<btp::HeaderA> : public byte_buffer
+{
+    byte_buffer_impl(const btp::HeaderA& header) : m_header(header) {}
+    void convert(ByteBuffer& buffer) const override
+    {
+        buffer.clear();
+        serialize_into_buffer(m_header, buffer);
+    }
+    std::size_t size() const override { return btp::HeaderA::length_bytes; }
+
+    const btp::HeaderA m_header;
+};
+
+template<>
 struct byte_buffer_impl<btp::HeaderB> : public byte_buffer
 {
     byte_buffer_impl(const btp::HeaderB& header) : m_header(header) {}
@@ -28,4 +42,3 @@ struct byte_buffer_impl<btp::HeaderB> : public byte_buffer
 } // namespace vanetza
 
 #endif /* HEADER_CONVERSION_HPP_SQVEUMFE */
-

--- a/vanetza/btp/tests/data_indication.cpp
+++ b/vanetza/btp/tests/data_indication.cpp
@@ -32,4 +32,3 @@ TEST(BtpDataIndication, construct_from_header_b) {
     EXPECT_EQ(gn_ind.remaining_packet_lifetime->raw(),
             btp_ind.remaining_packet_lifetime->raw());
 }
-

--- a/vanetza/btp/tests/header.cpp
+++ b/vanetza/btp/tests/header.cpp
@@ -6,6 +6,22 @@ using namespace vanetza;
 
 const ByteBuffer ref = { 0x38, 0x84, 0x01, 0x40 };
 
+TEST(BtpHeaderA, serialize) {
+    btp::HeaderA header;
+    header.destination_port = host_cast<uint16_t>(0x3884);
+    header.source_port = host_cast<uint16_t>(0x0140);
+    ByteBuffer buf;
+    serialize_into_buffer(header, buf);
+    EXPECT_EQ(ref, buf);
+}
+
+TEST(BtpHeaderA, deserialize) {
+    btp::HeaderA header;
+    deserialize_from_buffer(header, ref);
+    EXPECT_EQ(host_cast<uint16_t>(0x3884), header.destination_port);
+    EXPECT_EQ(host_cast<uint16_t>(0x0140), header.source_port);
+}
+
 TEST(BtpHeaderB, serialize) {
     btp::HeaderB header;
     header.destination_port = host_cast<uint16_t>(0x3884);
@@ -21,4 +37,3 @@ TEST(BtpHeaderB, deserialize) {
     EXPECT_EQ(host_cast<uint16_t>(0x3884), header.destination_port);
     EXPECT_EQ(host_cast<uint16_t>(0x0140), header.destination_port_info);
 }
-


### PR DESCRIPTION
I noticed these aren't supported while trying to implement an upper tester for the TTCN-3 test suite for BTP.