### PR TITLE
Certificate validator improvements

### DIFF
--- a/vanetza/security/CMakeLists.txt
+++ b/vanetza/security/CMakeLists.txt
@@ -36,7 +36,7 @@ add_vanetza_component(security
 )
 target_link_libraries(security PUBLIC Boost::serialization common net geonet)
 
-# crypto++ is a public mandatory dependency because of "NaiveCertificateManager"
+# crypto++ is a public mandatory dependency because of "NaiveCertificateProvider"
 if(TARGET CryptoPP::CryptoPP)
     set_property(TARGET security APPEND PROPERTY
         SOURCES backend_cryptopp.cpp)

--- a/vanetza/security/CMakeLists.txt
+++ b/vanetza/security/CMakeLists.txt
@@ -34,7 +34,7 @@ add_vanetza_component(security
     validity_restriction.cpp
     verify_service.cpp
 )
-target_link_libraries(security PUBLIC Boost::serialization common net)
+target_link_libraries(security PUBLIC Boost::serialization common net geonet)
 
 # crypto++ is a public mandatory dependency because of "NaiveCertificateManager"
 if(TARGET CryptoPP::CryptoPP)

--- a/vanetza/security/certificate.hpp
+++ b/vanetza/security/certificate.hpp
@@ -39,6 +39,7 @@ enum class CertificateInvalidReason
     INVALID_SIGNER,
     INVALID_NAME,
     TOO_LONG_CHAIN,
+    OFF_REGION,
 };
 
 class CertificateValidity

--- a/vanetza/security/certificate.hpp
+++ b/vanetza/security/certificate.hpp
@@ -30,54 +30,6 @@ struct Certificate
     uint8_t version() const { return 2; }
 };
 
-enum class CertificateInvalidReason
-{
-    BROKEN_TIME_PERIOD,
-    OFF_TIME_PERIOD,
-    UNKNOWN_SIGNER,
-    MISSING_SIGNATURE,
-    INVALID_SIGNER,
-    INVALID_NAME,
-    TOO_LONG_CHAIN,
-    OFF_REGION,
-};
-
-class CertificateValidity
-{
-public:
-    CertificateValidity() = default;
-
-    /**
-     * Create CertificateValidity signalling an invalid certificate
-     * \param reason Reason for invalidity
-     */
-    CertificateValidity(CertificateInvalidReason reason) : m_reason(reason) {}
-
-    /**
-     * \brief Create CertificateValidity signalling a valid certificate
-     * This method is equivalent to default construction but should be more expressive.
-     * \return validity
-     */
-    static CertificateValidity valid() { return CertificateValidity(); }
-
-    /**
-     * Check if status corresponds to a valid certificate
-     * \return true if certificate is valid
-     */
-    operator bool() const { return !m_reason; }
-
-    /**
-     * \brief Get reason for certificate invalidity
-     * This call is only safe if reason is available, i.e. check validity before!
-     *
-     * \return reason
-     */
-    CertificateInvalidReason reason() const { return *m_reason; }
-
-private:
-    boost::optional<CertificateInvalidReason> m_reason;
-};
-
 /**
  * \brief Calculates size of an certificate object
  *

--- a/vanetza/security/certificate.hpp
+++ b/vanetza/security/certificate.hpp
@@ -38,6 +38,7 @@ enum class CertificateInvalidReason
     MISSING_SIGNATURE,
     INVALID_SIGNER,
     INVALID_NAME,
+    TOO_LONG_CHAIN,
 };
 
 class CertificateValidity

--- a/vanetza/security/certificate_validator.hpp
+++ b/vanetza/security/certificate_validator.hpp
@@ -2,6 +2,7 @@
 #define CERTIFICATE_VALIDATOR_HPP
 
 #include <vanetza/security/certificate.hpp>
+#include <vanetza/security/verify_service.hpp>
 
 namespace vanetza
 {
@@ -16,7 +17,7 @@ public:
      * \param certificate given certificate
      * \return validity result
      */
-    virtual CertificateValidity check_certificate(const Certificate& certificate) = 0;
+    virtual DecapConfirm check_certificate(const Certificate& certificate) = 0;
 };
 
 } // namespace security

--- a/vanetza/security/decap_confirm.hpp
+++ b/vanetza/security/decap_confirm.hpp
@@ -35,7 +35,7 @@ enum class DecapReport
 
 /** \brief contains output of the verify process
 *   described in
-*   TS 102 723-8 v1.0.0 (2013-07)
+*   TS 102 723-8 v1.1.1 (2016-04)
 *   TS 102 636-4-1 v1.2.3 (2015-01)
 */
 struct DecapConfirm
@@ -43,9 +43,10 @@ struct DecapConfirm
     // plaintext_packet_length is gathered via ByteBuffer::size(); valid range 0 ... 2^16-1; mandatory
     PacketVariant plaintext_payload; // mandatory
     DecapReport report; // mandatory
-    CertificateValidity certificate_validity; // non-standard extension
-    boost::optional<HashedId8> certificate_id; // optional
-    // member field 'permissions' currently not used; optional
+    std::list<Certificate> certificate_chain; // non-standard extension
+    boost::optional<HashedId8> unknown_certificate; // non-standard extension
+    IntX its_aid;
+    // 'permissions' can be extracted from the certificate(s) in 'certificate_chain'
 };
 
 } // namespace security

--- a/vanetza/security/default_certificate_validator.cpp
+++ b/vanetza/security/default_certificate_validator.cpp
@@ -184,6 +184,12 @@ CertificateValidity DefaultCertificateValidator::check_certificate(const Certifi
                 continue;
             }
 
+            const auto signer_type = possible_signer.subject_info.subject_type;
+
+            if (signer_type != SubjectType::Authorization_Authority && signer_type != SubjectType::Root_Ca) {
+                continue;
+            }
+
             if (m_crypto_backend.verify_data(verification_key.get(), binary_cert, sig.get())) {
                 if (!check_time_consistency(current_cert, possible_signer)) {
                     return CertificateInvalidReason::BROKEN_TIME_PERIOD;
@@ -204,6 +210,12 @@ CertificateValidity DefaultCertificateValidator::check_certificate(const Certifi
         for (auto& possible_signer : m_cert_cache.lookup(signer_hash)) {
             auto verification_key = get_public_key(possible_signer);
             if (!verification_key) {
+                continue;
+            }
+
+            const auto signer_type = possible_signer.subject_info.subject_type;
+
+            if (signer_type != SubjectType::Authorization_Authority && signer_type != SubjectType::Root_Ca) {
                 continue;
             }
 

--- a/vanetza/security/default_certificate_validator.cpp
+++ b/vanetza/security/default_certificate_validator.cpp
@@ -12,6 +12,76 @@ namespace vanetza
 {
 namespace security
 {
+namespace
+{
+
+bool extract_validity_time(const Certificate& certificate, boost::optional<Time32>& start, boost::optional<Time32>& end)
+{
+    unsigned certificate_time_constraints = 0;
+
+    for (auto& restriction : certificate.validity_restriction) {
+        ValidityRestriction validity_restriction = restriction;
+        ValidityRestrictionType type = get_type(validity_restriction);
+
+        if (type == ValidityRestrictionType::Time_Start_And_End) {
+            // change start and end time of certificate validity
+            StartAndEndValidity start_and_end = boost::get<StartAndEndValidity>(validity_restriction);
+
+            // check if certificate validity restriction timestamps are logically correct
+            if (start_and_end.start_validity >= start_and_end.end_validity) {
+                return false;
+            }
+
+            start = start_and_end.start_validity;
+            end = start_and_end.end_validity;
+
+            ++certificate_time_constraints;
+        } else if (type == ValidityRestrictionType::Time_End) {
+            EndValidity time_end = boost::get<EndValidity>(validity_restriction);
+            end = time_end;
+
+            ++certificate_time_constraints;
+        } else if (type == ValidityRestrictionType::Time_Start_And_Duration) {
+            StartAndDurationValidity start_and_duration = boost::get<StartAndDurationValidity>(validity_restriction);
+
+            start = start_and_duration.start_validity;
+            end = start_and_duration.start_validity + start_and_duration.duration.to_seconds().count();
+
+            ++certificate_time_constraints;
+        }
+    }
+
+    return certificate_time_constraints == 1;
+}
+
+bool check_time_consistent(const Certificate& certificate, const Certificate& signer)
+{
+    boost::optional<Time32> certificate_time_start;
+    boost::optional<Time32> certificate_time_end;
+
+    boost::optional<Time32> signer_time_start;
+    boost::optional<Time32> signer_time_end;
+
+    if (!extract_validity_time(certificate, certificate_time_start, certificate_time_end)) {
+        return false;
+    }
+
+    if (!extract_validity_time(signer, signer_time_start, signer_time_end)) {
+        return false;
+    }
+
+    if (signer_time_start && *signer_time_start > *certificate_time_start) {
+        return false;
+    }
+
+    if (signer_time_end && *signer_time_end < *certificate_time_end) {
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
 
 DefaultCertificateValidator::DefaultCertificateValidator(Backend& backend, const Clock::time_point& time_now,
         const TrustStore& trust_store, CertificateCache& cert_cache) :
@@ -24,59 +94,38 @@ DefaultCertificateValidator::DefaultCertificateValidator(Backend& backend, const
 
 CertificateValidity DefaultCertificateValidator::check_certificate(const Certificate& certificate)
 {
+    return check_certificate(certificate, 10);
+}
+
+CertificateValidity DefaultCertificateValidator::check_certificate(const Certificate& certificate, uint8_t max_depth)
+{
+    if (max_depth == 0) {
+        return CertificateInvalidReason::TOO_LONG_CHAIN;
+    }
+
+    boost::optional<Time32> certificate_time_start;
+    boost::optional<Time32> certificate_time_end;
+
     // ensure exactly one time validity constraint is present
     // section 6.7 in TS 103 097 v1.2.1
-    unsigned certificate_time_constraints = 0;
+    if (!extract_validity_time(certificate, certificate_time_start, certificate_time_end)) {
+        return CertificateInvalidReason::BROKEN_TIME_PERIOD;
+    }
 
-    // check validity restriction
-    for (auto& restriction : certificate.validity_restriction) {
-        ValidityRestriction validity_restriction = restriction;
-        ValidityRestrictionType type = get_type(validity_restriction);
-
-        if (type == ValidityRestrictionType::Time_Start_And_End) {
-            // change start and end time of certificate validity
-            StartAndEndValidity start_and_end = boost::get<StartAndEndValidity>(validity_restriction);
-
-            // check if certificate validity restriction timestamps are logically correct
-            if (start_and_end.start_validity >= start_and_end.end_validity) {
-                return CertificateInvalidReason::BROKEN_TIME_PERIOD;
-            }
-
-            // check if certificate is premature or outdated
-            auto now = convert_time32(m_time_now);
-            if (now < start_and_end.start_validity || now > start_and_end.end_validity) {
-                return CertificateInvalidReason::OFF_TIME_PERIOD;
-            }
-
-            ++certificate_time_constraints;
-        } else if (type == ValidityRestrictionType::Time_End) {
-            EndValidity end = boost::get<EndValidity>(validity_restriction);
-
-            // check if certificate is outdated
-            auto now = convert_time32(m_time_now);
-            if (now > end) {
-                return CertificateInvalidReason::OFF_TIME_PERIOD;
-            }
-
-            ++certificate_time_constraints;
-        } else if (type == ValidityRestrictionType::Time_Start_And_Duration) {
-            StartAndDurationValidity start_and_duration = boost::get<StartAndDurationValidity>(validity_restriction);
-
-            // check if certificate is premature or outdated
-            auto now = convert_time32(m_time_now);
-            std::chrono::seconds duration = start_and_duration.duration.to_seconds();
-            auto end = start_and_duration.start_validity + duration.count();
-            if (now < start_and_duration.start_validity || now > end) {
-                return CertificateInvalidReason::OFF_TIME_PERIOD;
-            }
-
-            ++certificate_time_constraints;
+    // check if certificate is premature or outdated
+    auto now = convert_time32(m_time_now);
+    if (certificate_time_start && certificate_time_end) {
+        if (*certificate_time_start >= certificate_time_end) {
+            return CertificateInvalidReason::BROKEN_TIME_PERIOD;
         }
     }
 
-    // if not exactly one time constraint is given, we fail instead of considering it valid
-    if (1 != certificate_time_constraints) {
-        return CertificateInvalidReason::BROKEN_TIME_PERIOD;
+    if (certificate_time_start && now < *certificate_time_start) {
+        return CertificateInvalidReason::OFF_TIME_PERIOD;
+    }
+
+    if (certificate_time_end && now > *certificate_time_end) {
+        return CertificateInvalidReason::OFF_TIME_PERIOD;
     }
 
     SubjectType subject_type = certificate.subject_info.subject_type;
@@ -105,13 +154,16 @@ CertificateValidity DefaultCertificateValidator::check_certificate(const Certifi
     const std::list<Certificate> possible_trusted_signers = m_trust_store.lookup(signer_hash);
     for (auto& possible_signer : possible_trusted_signers) {
         auto verification_key = get_public_key(possible_signer);
-
         // this should never happen, as the verify service already ensures a key is present
         if (!verification_key) {
             continue;
         }
 
         if (m_crypto_backend.verify_data(verification_key.get(), cert, sig.get())) {
+            if (!check_time_consistent(certificate, possible_signer)) {
+                return CertificateInvalidReason::BROKEN_TIME_PERIOD;
+            }
+
             return CertificateValidity::valid();
         }
     }
@@ -125,11 +177,17 @@ CertificateValidity DefaultCertificateValidator::check_certificate(const Certifi
         }
 
         if (m_crypto_backend.verify_data(verification_key.get(), cert, sig.get())) {
-            // TODO: Add max depth limitation
-            CertificateValidity validity = check_certificate(possible_signer);
+            if (!check_time_consistent(certificate, possible_signer)) {
+                return CertificateInvalidReason::BROKEN_TIME_PERIOD;
+            }
+
+            CertificateValidity validity = check_certificate(possible_signer, max_depth - 1);
+
             if (validity) {
+                // Renews certificate in cache
                 m_cert_cache.insert(possible_signer);
             }
+
             return validity;
         }
     }

--- a/vanetza/security/default_certificate_validator.cpp
+++ b/vanetza/security/default_certificate_validator.cpp
@@ -37,8 +37,7 @@ bool extract_validity_time(const Certificate& certificate, boost::optional<Time3
 
             ++certificate_time_constraints;
         } else if (type == ValidityRestrictionType::Time_End) {
-            EndValidity time_end = boost::get<EndValidity>(validity_restriction);
-            end = time_end;
+            end = boost::get<EndValidity>(validity_restriction);
 
             ++certificate_time_constraints;
         } else if (type == ValidityRestrictionType::Time_Start_And_Duration) {
@@ -70,12 +69,24 @@ bool check_time_consistent(const Certificate& certificate, const Certificate& si
         return false;
     }
 
-    if (signer_time_start && *signer_time_start > *certificate_time_start) {
-        return false;
+    if (signer_time_start) {
+        if (!certificate_time_start) {
+            return false;
+        }
+
+        if (*signer_time_start > *certificate_time_start) {
+            return false;
+        }
     }
 
-    if (signer_time_end && *signer_time_end < *certificate_time_end) {
-        return false;
+    if (signer_time_end) {
+        if (!certificate_time_end) {
+            return false;
+        }
+
+        if (*signer_time_end < *certificate_time_end) {
+            return false;
+        }
     }
 
     return true;

--- a/vanetza/security/default_certificate_validator.hpp
+++ b/vanetza/security/default_certificate_validator.hpp
@@ -30,7 +30,7 @@ public:
      * \param certificate to verify
      * \return certificate status
      */
-    CertificateValidity check_certificate(const Certificate& certificate) override;
+    DecapConfirm check_certificate(const Certificate& certificate) override;
 
     /**
      * \brief Update local position vector

--- a/vanetza/security/default_certificate_validator.hpp
+++ b/vanetza/security/default_certificate_validator.hpp
@@ -36,6 +36,8 @@ private:
     const Clock::time_point& m_time_now;
     const TrustStore& m_trust_store;
     CertificateCache& m_cert_cache;
+
+    CertificateValidity check_certificate(const Certificate& certificate, uint8_t max_depth);
 };
 
 } // namespace security

--- a/vanetza/security/default_certificate_validator.hpp
+++ b/vanetza/security/default_certificate_validator.hpp
@@ -2,6 +2,7 @@
 #define DEFAULT_CERTIFICATE_VALIDATOR_HPP_MTULFLKX
 
 #include <vanetza/common/clock.hpp>
+#include <vanetza/geonet/position_vector.hpp>
 #include <vanetza/security/backend.hpp>
 #include <vanetza/security/certificate_validator.hpp>
 
@@ -31,11 +32,22 @@ public:
      */
     CertificateValidity check_certificate(const Certificate& certificate) override;
 
+    /**
+     * \brief Update local position vector
+     * \note GN Address of given LongPositionVector is ignored!
+     *
+     * \param lpv Set positional data according to this argument
+     */
+    void update(const vanetza::geonet::LongPositionVector&);
+
 private:
     Backend& m_crypto_backend;
     const Clock::time_point& m_time_now;
     const TrustStore& m_trust_store;
     CertificateCache& m_cert_cache;
+    vanetza::geonet::LongPositionVector m_local_position_vector;
+
+    bool check_region(const Certificate& certificate);
 };
 
 } // namespace security

--- a/vanetza/security/default_certificate_validator.hpp
+++ b/vanetza/security/default_certificate_validator.hpp
@@ -36,8 +36,6 @@ private:
     const Clock::time_point& m_time_now;
     const TrustStore& m_trust_store;
     CertificateCache& m_cert_cache;
-
-    CertificateValidity check_certificate(const Certificate& certificate, uint8_t max_depth);
 };
 
 } // namespace security

--- a/vanetza/security/naive_certificate_provider.hpp
+++ b/vanetza/security/naive_certificate_provider.hpp
@@ -43,6 +43,12 @@ public:
     const ecdsa256::PrivateKey& own_private_key() override;
 
     /**
+     * \brief get ticket signer certificate (same for all instances)
+     * \return signing authorization authoirity certificate
+     */
+    const Certificate& aa_certificate();
+
+    /**
      * \brief get root certificate (same for all instances)
      * \return signing root certificate
      */
@@ -69,12 +75,6 @@ private:
      * \return root key
      */
     const ecdsa256::KeyPair& root_key_pair();
-
-    /**
-     * \brief get ticket signer certificate (same for all instances)
-     * \return signing authorization authoirity certificate
-     */
-    const Certificate& aa_certificate();
 
     /**
      * \brief generate a authorization authority certificate

--- a/vanetza/security/naive_certificate_provider.hpp
+++ b/vanetza/security/naive_certificate_provider.hpp
@@ -48,6 +48,15 @@ public:
      */
     const Certificate& root_certificate();
 
+    /**
+     * \brief generate a authorization ticket
+     *
+     * \param mutator allows mutating the certificate directly before signing, useful in tests
+     *
+     * \return generated certificate
+     */
+    Certificate generate_authorization_ticket(std::function<void(Certificate&)> mutator);
+
 private:
     /**
      * \brief get root key (same for all instances)
@@ -66,13 +75,6 @@ private:
      * \return signing authorization authoirity certificate
      */
     const Certificate& aa_certificate();
-
-    /**
-     * \brief generate a authorization ticket
-     *
-     * \return generated certificate
-     */
-    Certificate generate_authorization_ticket();
 
     /**
      * \brief generate a authorization authority certificate

--- a/vanetza/security/naive_certificate_provider.hpp
+++ b/vanetza/security/naive_certificate_provider.hpp
@@ -55,13 +55,16 @@ public:
     const Certificate& root_certificate();
 
     /**
-     * \brief generate a authorization ticket
-     *
-     * \param mutator allows mutating the certificate directly before signing, useful in tests
-     *
+     * \brief generate an authorization ticket
      * \return generated certificate
      */
-    Certificate generate_authorization_ticket(std::function<void(Certificate&)> mutator);
+    Certificate generate_authorization_ticket();
+
+    /**
+     * \brief sign an authorization ticket
+     * \param certificate certificate to sign
+     */
+    void sign_authorization_ticket(Certificate& certificate);
 
 private:
     /**

--- a/vanetza/security/null_certificate_validator.cpp
+++ b/vanetza/security/null_certificate_validator.cpp
@@ -5,16 +5,17 @@ namespace vanetza
 namespace security
 {
 
-NullCertificateValidator::NullCertificateValidator() : m_check_result(CertificateInvalidReason::UNKNOWN_SIGNER)
+NullCertificateValidator::NullCertificateValidator()
 {
+    m_check_result.report = DecapReport::Invalid_Certificate;
 }
 
-CertificateValidity NullCertificateValidator::check_certificate(const Certificate&)
+DecapConfirm NullCertificateValidator::check_certificate(const Certificate&)
 {
     return m_check_result;
 }
 
-void NullCertificateValidator::certificate_check_result(const CertificateValidity& result)
+void NullCertificateValidator::certificate_check_result(const DecapConfirm& result)
 {
     m_check_result = result;
 }

--- a/vanetza/security/null_certificate_validator.hpp
+++ b/vanetza/security/null_certificate_validator.hpp
@@ -13,16 +13,16 @@ class NullCertificateValidator : public CertificateValidator
 public:
     NullCertificateValidator();
 
-    CertificateValidity check_certificate(const Certificate&) override;
+    DecapConfirm check_certificate(const Certificate&) override;
 
     /**
      * Set predefined result of check_certificate() calls
      * \param result predefined result
      */
-    void certificate_check_result(const CertificateValidity& result);
+    void certificate_check_result(const DecapConfirm& result);
 
 private:
-    CertificateValidity m_check_result;
+    DecapConfirm m_check_result;
 };
 
 } // namespace security

--- a/vanetza/security/region.cpp
+++ b/vanetza/security/region.cpp
@@ -35,6 +35,14 @@ RegionType get_type(const GeographicRegion& reg)
     return boost::apply_visitor(visit, reg);
 }
 
+vanetza::geonet::GeodeticPosition convert_geodetic_position(const TwoDLocation& position)
+{
+    return vanetza::geonet::GeodeticPosition(
+        static_cast<boost::units::quantity<boost::units::degree::plane_angle> >(position.latitude),
+        static_cast<boost::units::quantity<boost::units::degree::plane_angle> >(position.longitude)
+    );
+}
+
 size_t get_size(const TwoDLocation& loc)
 {
     size_t size = 0;

--- a/vanetza/security/region.hpp
+++ b/vanetza/security/region.hpp
@@ -1,6 +1,7 @@
 #ifndef REGION_HPP_NUISLPMU
 #define REGION_HPP_NUISLPMU
 
+#include <vanetza/geonet/areas.hpp>
 #include <vanetza/geonet/units.hpp>
 #include <vanetza/security/int_x.hpp>
 #include <boost/variant/variant.hpp>
@@ -82,6 +83,13 @@ using GeographicRegion = boost::variant<
  * \return RegionType
  */
 RegionType get_type(const GeographicRegion&);
+
+/**
+ * \brief Convert TwoDLocation to GeodeticPosition
+ * \param position
+ * \return GeodeticPosition
+ */
+vanetza::geonet::GeodeticPosition convert_geodetic_position(const TwoDLocation& position);
 
 /**
  * \brief Calculates size of a TwoDLocation

--- a/vanetza/security/security_entity.cpp
+++ b/vanetza/security/security_entity.cpp
@@ -46,11 +46,8 @@ EncapConfirm SecurityEntity::encapsulate_packet(EncapRequest&& encap_request)
 
 DecapConfirm SecurityEntity::decapsulate_packet(DecapRequest&& decap_request)
 {
-    VerifyConfirm verify_confirm = m_verify_service(VerifyRequest { decap_request.sec_packet });
-    DecapConfirm decap_confirm;
+    DecapConfirm decap_confirm = m_verify_service(decap_request);
     decap_confirm.plaintext_payload = std::move(decap_request.sec_packet.payload.data);
-    decap_confirm.report = static_cast<DecapReport>(verify_confirm.report);
-    decap_confirm.certificate_validity = verify_confirm.certificate_validity;
     return decap_confirm;
 }
 

--- a/vanetza/security/tests/default_certificate_validator.cpp
+++ b/vanetza/security/tests/default_certificate_validator.cpp
@@ -70,10 +70,10 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_end)
     Certificate cert = cert_provider.generate_authorization_ticket();
     certificate_remove_time_constraints(cert);
 
-    StartAndEndValidity validity;
-    validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
-    validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
-    cert.validity_restriction.push_back(validity);
+    StartAndEndValidity restriction;
+    restriction.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+    restriction.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
+    cert.validity_restriction.push_back(restriction);
 
     cert_provider.sign_authorization_ticket(cert);
 
@@ -89,10 +89,10 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_duration)
     Certificate cert = cert_provider.generate_authorization_ticket();
     certificate_remove_time_constraints(cert);
 
-    StartAndDurationValidity validity;
-    validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
-    validity.duration = Duration(23, Duration::Units::Hours);
-    cert.validity_restriction.push_back(validity);
+    StartAndDurationValidity restriction;
+    restriction.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+    restriction.duration = Duration(23, Duration::Units::Hours);
+    cert.validity_restriction.push_back(restriction);
 
     cert_provider.sign_authorization_ticket(cert);
 
@@ -108,8 +108,8 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_end)
     Certificate cert = cert_provider.generate_authorization_ticket();
     certificate_remove_time_constraints(cert);
 
-    EndValidity validity = convert_time32(runtime.now() + std::chrono::hours(23));
-    cert.validity_restriction.push_back(validity);
+    EndValidity restriction = convert_time32(runtime.now() + std::chrono::hours(23));
+    cert.validity_restriction.push_back(restriction);
 
     cert_provider.sign_authorization_ticket(cert);
 
@@ -155,10 +155,10 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_with_parent)
     Certificate cert = cert_provider.generate_authorization_ticket();
     certificate_remove_time_constraints(cert);
 
-    StartAndEndValidity validity;
-    validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(3));
-    validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
-    cert.validity_restriction.push_back(validity);
+    StartAndEndValidity restriction;
+    restriction.start_validity = convert_time32(runtime.now() - std::chrono::hours(3));
+    restriction.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
+    cert.validity_restriction.push_back(restriction);
 
     cert_provider.sign_authorization_ticket(cert);
 
@@ -176,10 +176,10 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_start_and_end)
     Certificate cert = cert_provider.generate_authorization_ticket();
     certificate_remove_time_constraints(cert);
 
-    StartAndEndValidity validity;
-    validity.start_validity = convert_time32(runtime.now() + std::chrono::hours(3));
-    validity.end_validity = convert_time32(runtime.now() - std::chrono::hours(23));
-    cert.validity_restriction.push_back(validity);
+    StartAndEndValidity restriction;
+    restriction.start_validity = convert_time32(runtime.now() + std::chrono::hours(3));
+    restriction.end_validity = convert_time32(runtime.now() - std::chrono::hours(23));
+    cert.validity_restriction.push_back(restriction);
 
     cert_provider.sign_authorization_ticket(cert);
 

--- a/vanetza/security/tests/default_certificate_validator.cpp
+++ b/vanetza/security/tests/default_certificate_validator.cpp
@@ -35,22 +35,22 @@ protected:
 
 TEST_F(DefaultCertificateValidatorTest, validity_time)
 {
-    Certificate cert = cert_provider.own_certificate();
-
-    // remove any time constraint from certificate
-    for (auto it = cert.validity_restriction.begin(); it != cert.validity_restriction.end(); ++it) {
-        const ValidityRestriction& restriction = *it;
-        ValidityRestrictionType type = get_type(restriction);
-        switch (type) {
-            case ValidityRestrictionType::Time_End:
-            case ValidityRestrictionType::Time_Start_And_End:
-            case ValidityRestrictionType::Time_Start_And_Duration:
-                it = cert.validity_restriction.erase(it);
-                break;
-            default:
-                break;
+    Certificate cert = cert_provider.generate_authorization_ticket([](Certificate& cert) {
+        // remove any time constraint from certificate
+        for (auto it = cert.validity_restriction.begin(); it != cert.validity_restriction.end(); ++it) {
+            const ValidityRestriction& restriction = *it;
+            ValidityRestrictionType type = get_type(restriction);
+            switch (type) {
+                case ValidityRestrictionType::Time_End:
+                case ValidityRestrictionType::Time_Start_And_End:
+                case ValidityRestrictionType::Time_Start_And_Duration:
+                    it = cert.validity_restriction.erase(it);
+                    break;
+                default:
+                    break;
+            }
         }
-    }
+    });
 
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_FALSE(validity);

--- a/vanetza/security/tests/default_certificate_validator.cpp
+++ b/vanetza/security/tests/default_certificate_validator.cpp
@@ -33,27 +33,153 @@ protected:
     DefaultCertificateValidator cert_validator;
 };
 
-TEST_F(DefaultCertificateValidatorTest, validity_time)
+void certificate_remove_time_constraints(Certificate& cert)
+{
+    for (auto it = cert.validity_restriction.begin(); it != cert.validity_restriction.end(); ++it) {
+        const ValidityRestriction& restriction = *it;
+        ValidityRestrictionType type = get_type(restriction);
+        switch (type) {
+            case ValidityRestrictionType::Time_End:
+            case ValidityRestrictionType::Time_Start_And_End:
+            case ValidityRestrictionType::Time_Start_And_Duration:
+                it = cert.validity_restriction.erase(it);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+TEST_F(DefaultCertificateValidatorTest, validity_time_no_constraint)
 {
     Certificate cert = cert_provider.generate_authorization_ticket([](Certificate& cert) {
-        // remove any time constraint from certificate
-        for (auto it = cert.validity_restriction.begin(); it != cert.validity_restriction.end(); ++it) {
-            const ValidityRestriction& restriction = *it;
-            ValidityRestrictionType type = get_type(restriction);
-            switch (type) {
-                case ValidityRestrictionType::Time_End:
-                case ValidityRestrictionType::Time_Start_And_End:
-                case ValidityRestrictionType::Time_Start_And_Duration:
-                    it = cert.validity_restriction.erase(it);
-                    break;
-                default:
-                    break;
-            }
-        }
+        certificate_remove_time_constraints(cert);
     });
+
+    cert_cache.insert(cert_provider.aa_certificate());
+    cert_cache.insert(cert_provider.root_certificate());
 
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_FALSE(validity);
     EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, validity.reason());
-    // TODO: check that presence of exactly one time constraint is considered valid
+}
+
+TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_end)
+{
+    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
+        certificate_remove_time_constraints(cert);
+
+        StartAndEndValidity validity;
+        validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+        validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
+        cert.validity_restriction.push_back(validity);
+    });
+
+    cert_cache.insert(cert_provider.aa_certificate());
+    cert_cache.insert(cert_provider.root_certificate());
+
+    CertificateValidity validity = cert_validator.check_certificate(cert);
+    ASSERT_TRUE(validity);
+}
+
+TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_duration)
+{
+    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
+        certificate_remove_time_constraints(cert);
+
+        StartAndDurationValidity validity;
+        validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+        validity.duration = Duration(23, Duration::Units::Hours);
+        cert.validity_restriction.push_back(validity);
+    });
+
+    cert_cache.insert(cert_provider.aa_certificate());
+    cert_cache.insert(cert_provider.root_certificate());
+
+    CertificateValidity validity = cert_validator.check_certificate(cert);
+    ASSERT_TRUE(validity);
+}
+
+TEST_F(DefaultCertificateValidatorTest, validity_time_end)
+{
+    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
+        certificate_remove_time_constraints(cert);
+
+        EndValidity validity = convert_time32(runtime.now() + std::chrono::hours(23));
+        cert.validity_restriction.push_back(validity);
+    });
+
+    cert_cache.insert(cert_provider.aa_certificate());
+    cert_cache.insert(cert_provider.root_certificate());
+
+    // Time period broken, because AA and root CA have start time
+    CertificateValidity validity = cert_validator.check_certificate(cert);
+    ASSERT_FALSE(validity);
+    EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, validity.reason());
+
+    // TODO: Add test for certificate, AA and root CA with EndValidity
+}
+
+TEST_F(DefaultCertificateValidatorTest, validity_time_two_constraints)
+{
+    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
+        certificate_remove_time_constraints(cert);
+
+        StartAndEndValidity start_and_end_validity;
+        start_and_end_validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+        start_and_end_validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
+        cert.validity_restriction.push_back(start_and_end_validity);
+
+        StartAndDurationValidity start_and_duration_validity;
+        start_and_duration_validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+        start_and_duration_validity.duration = Duration(23, Duration::Units::Hours);
+        cert.validity_restriction.push_back(start_and_duration_validity);
+    });
+
+    cert_cache.insert(cert_provider.aa_certificate());
+    cert_cache.insert(cert_provider.root_certificate());
+
+    CertificateValidity validity = cert_validator.check_certificate(cert);
+    ASSERT_FALSE(validity);
+    EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, validity.reason());
+}
+
+TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_with_parent)
+{
+    // The generated authorization ticket's start time is prior to the AA certificate's start time
+    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
+        certificate_remove_time_constraints(cert);
+
+        StartAndEndValidity validity;
+        validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(3));
+        validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
+        cert.validity_restriction.push_back(validity);
+    });
+
+    cert_cache.insert(cert_provider.aa_certificate());
+    cert_cache.insert(cert_provider.root_certificate());
+
+    CertificateValidity validity = cert_validator.check_certificate(cert);
+    ASSERT_FALSE(validity);
+    EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, validity.reason());
+}
+
+TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_start_and_end)
+{
+    // The generated authorization ticket's start time is prior to the AA certificate's start time
+    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
+        certificate_remove_time_constraints(cert);
+
+        StartAndEndValidity validity;
+        validity.start_validity = convert_time32(runtime.now() + std::chrono::hours(3));
+        validity.end_validity = convert_time32(runtime.now() - std::chrono::hours(23));
+        cert.validity_restriction.push_back(validity);
+    });
+
+    cert_cache.insert(cert_provider.aa_certificate());
+    cert_cache.insert(cert_provider.root_certificate());
+
+    CertificateValidity validity = cert_validator.check_certificate(cert);
+    ASSERT_FALSE(validity);
+    EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, validity.reason());
 }

--- a/vanetza/security/tests/default_certificate_validator.cpp
+++ b/vanetza/security/tests/default_certificate_validator.cpp
@@ -53,9 +53,9 @@ void certificate_remove_time_constraints(Certificate& cert)
 
 TEST_F(DefaultCertificateValidatorTest, validity_time_no_constraint)
 {
-    Certificate cert = cert_provider.generate_authorization_ticket([](Certificate& cert) {
-        certificate_remove_time_constraints(cert);
-    });
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    certificate_remove_time_constraints(cert);
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());
@@ -67,14 +67,15 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_no_constraint)
 
 TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_end)
 {
-    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
-        certificate_remove_time_constraints(cert);
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    certificate_remove_time_constraints(cert);
 
-        StartAndEndValidity validity;
-        validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
-        validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
-        cert.validity_restriction.push_back(validity);
-    });
+    StartAndEndValidity validity;
+    validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+    validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
+    cert.validity_restriction.push_back(validity);
+
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());
@@ -85,14 +86,15 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_end)
 
 TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_duration)
 {
-    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
-        certificate_remove_time_constraints(cert);
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    certificate_remove_time_constraints(cert);
 
-        StartAndDurationValidity validity;
-        validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
-        validity.duration = Duration(23, Duration::Units::Hours);
-        cert.validity_restriction.push_back(validity);
-    });
+    StartAndDurationValidity validity;
+    validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+    validity.duration = Duration(23, Duration::Units::Hours);
+    cert.validity_restriction.push_back(validity);
+
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());
@@ -103,12 +105,13 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_duration)
 
 TEST_F(DefaultCertificateValidatorTest, validity_time_end)
 {
-    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
-        certificate_remove_time_constraints(cert);
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    certificate_remove_time_constraints(cert);
 
-        EndValidity validity = convert_time32(runtime.now() + std::chrono::hours(23));
-        cert.validity_restriction.push_back(validity);
-    });
+    EndValidity validity = convert_time32(runtime.now() + std::chrono::hours(23));
+    cert.validity_restriction.push_back(validity);
+
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());
@@ -123,19 +126,20 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_end)
 
 TEST_F(DefaultCertificateValidatorTest, validity_time_two_constraints)
 {
-    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
-        certificate_remove_time_constraints(cert);
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    certificate_remove_time_constraints(cert);
 
-        StartAndEndValidity start_and_end_validity;
-        start_and_end_validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
-        start_and_end_validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
-        cert.validity_restriction.push_back(start_and_end_validity);
+    StartAndEndValidity start_and_end_validity;
+    start_and_end_validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+    start_and_end_validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
+    cert.validity_restriction.push_back(start_and_end_validity);
 
-        StartAndDurationValidity start_and_duration_validity;
-        start_and_duration_validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
-        start_and_duration_validity.duration = Duration(23, Duration::Units::Hours);
-        cert.validity_restriction.push_back(start_and_duration_validity);
-    });
+    StartAndDurationValidity start_and_duration_validity;
+    start_and_duration_validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
+    start_and_duration_validity.duration = Duration(23, Duration::Units::Hours);
+    cert.validity_restriction.push_back(start_and_duration_validity);
+
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());
@@ -148,14 +152,15 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_two_constraints)
 TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_with_parent)
 {
     // The generated authorization ticket's start time is prior to the AA certificate's start time
-    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
-        certificate_remove_time_constraints(cert);
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    certificate_remove_time_constraints(cert);
 
-        StartAndEndValidity validity;
-        validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(3));
-        validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
-        cert.validity_restriction.push_back(validity);
-    });
+    StartAndEndValidity validity;
+    validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(3));
+    validity.end_validity = convert_time32(runtime.now() + std::chrono::hours(23));
+    cert.validity_restriction.push_back(validity);
+
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());
@@ -168,14 +173,15 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_with_parent)
 TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_start_and_end)
 {
     // The generated authorization ticket's start time is prior to the AA certificate's start time
-    Certificate cert = cert_provider.generate_authorization_ticket([this](Certificate& cert) {
-        certificate_remove_time_constraints(cert);
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    certificate_remove_time_constraints(cert);
 
-        StartAndEndValidity validity;
-        validity.start_validity = convert_time32(runtime.now() + std::chrono::hours(3));
-        validity.end_validity = convert_time32(runtime.now() - std::chrono::hours(23));
-        cert.validity_restriction.push_back(validity);
-    });
+    StartAndEndValidity validity;
+    validity.start_validity = convert_time32(runtime.now() + std::chrono::hours(3));
+    validity.end_validity = convert_time32(runtime.now() - std::chrono::hours(23));
+    cert.validity_restriction.push_back(validity);
+
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());
@@ -187,19 +193,21 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_start_and_end)
 
 TEST_F(DefaultCertificateValidatorTest, validity_region_without_position)
 {
-    Certificate cert = cert_provider.generate_authorization_ticket([](Certificate& cert) {
-        TwoDLocation center {
-            static_cast<geo_angle_i32t>(10 * units::degree),
-            static_cast<geo_angle_i32t>(20 * units::degree)
-        };
+    Certificate cert = cert_provider.generate_authorization_ticket();
 
-        CircularRegion region {
-            center,
-            static_cast<distance_u16t>(10 * units::si::meter)
-        };
+    TwoDLocation center {
+        static_cast<geo_angle_i32t>(10 * units::degree),
+        static_cast<geo_angle_i32t>(20 * units::degree)
+    };
 
-        cert.validity_restriction.push_back(region);
-    });
+    CircularRegion region {
+        center,
+        static_cast<distance_u16t>(10 * units::si::meter)
+    };
+
+    cert.validity_restriction.push_back(region);
+
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());
@@ -211,19 +219,21 @@ TEST_F(DefaultCertificateValidatorTest, validity_region_without_position)
 
 TEST_F(DefaultCertificateValidatorTest, validity_region_circle)
 {
-    Certificate cert = cert_provider.generate_authorization_ticket([](Certificate& cert) {
-        TwoDLocation center {
-            static_cast<geo_angle_i32t>(10 * units::degree),
-            static_cast<geo_angle_i32t>(20 * units::degree)
-        };
+    Certificate cert = cert_provider.generate_authorization_ticket();
 
-        CircularRegion region {
-            center,
-            static_cast<distance_u16t>(10 * units::si::meter)
-        };
+    TwoDLocation center {
+        static_cast<geo_angle_i32t>(10 * units::degree),
+        static_cast<geo_angle_i32t>(20 * units::degree)
+    };
 
-        cert.validity_restriction.push_back(region);
-    });
+    CircularRegion region {
+        center,
+        static_cast<distance_u16t>(10 * units::si::meter)
+    };
+
+    cert.validity_restriction.push_back(region);
+
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());
@@ -252,27 +262,29 @@ TEST_F(DefaultCertificateValidatorTest, validity_region_circle)
 
 TEST_F(DefaultCertificateValidatorTest, validity_region_rectangle)
 {
-    Certificate cert = cert_provider.generate_authorization_ticket([](Certificate& cert) {
-        TwoDLocation northwest {
-            static_cast<geo_angle_i32t>(10 * units::degree),
-            static_cast<geo_angle_i32t>(10 * units::degree)
-        };
+    Certificate cert = cert_provider.generate_authorization_ticket();
 
-        TwoDLocation southeast {
-            static_cast<geo_angle_i32t>(20 * units::degree),
-            static_cast<geo_angle_i32t>(20 * units::degree)
-        };
+    TwoDLocation northwest {
+        static_cast<geo_angle_i32t>(10 * units::degree),
+        static_cast<geo_angle_i32t>(10 * units::degree)
+    };
 
-        RectangularRegion region {
-            northwest,
-            southeast
-        };
+    TwoDLocation southeast {
+        static_cast<geo_angle_i32t>(20 * units::degree),
+        static_cast<geo_angle_i32t>(20 * units::degree)
+    };
 
-        std::list<RectangularRegion> regions;
-        regions.push_back(region);
+    RectangularRegion region {
+        northwest,
+        southeast
+    };
 
-        cert.validity_restriction.push_back(regions);
-    });
+    std::list<RectangularRegion> regions;
+    regions.push_back(region);
+
+    cert.validity_restriction.push_back(regions);
+
+    cert_provider.sign_authorization_ticket(cert);
 
     cert_cache.insert(cert_provider.aa_certificate());
     cert_cache.insert(cert_provider.root_certificate());

--- a/vanetza/security/tests/security_entity.cpp
+++ b/vanetza/security/tests/security_entity.cpp
@@ -3,8 +3,10 @@
 #include <vanetza/security/backend.hpp>
 #include <vanetza/security/certificate_cache.hpp>
 #include <vanetza/security/default_certificate_validator.hpp>
+#include <vanetza/security/its_aid.hpp>
 #include <vanetza/security/naive_certificate_provider.hpp>
 #include <vanetza/security/security_entity.hpp>
+#include <vanetza/security/signer_info.hpp>
 #include <vanetza/security/static_certificate_provider.hpp>
 #include <vanetza/security/trust_store.hpp>
 #include <vanetza/security/tests/check_payload.hpp>
@@ -245,7 +247,7 @@ TEST_F(SecurityEntityTest, verify_message_modified_certificate_subject_assurance
 
 TEST_F(SecurityEntityTest, verify_message_outdated_certificate)
 {
-    // forge certificate with outdatet validity
+    // forge certificate with outdated validity
     StartAndEndValidity outdated_validity;
     outdated_validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
     outdated_validity.end_validity = convert_time32(runtime.now() - std::chrono::minutes(1));
@@ -395,6 +397,82 @@ TEST_F(SecurityEntityTest, verify_message_without_signer_info)
     DecapConfirm decap_confirm = security.decapsulate_packet(std::move(decap_request));
     // check if verify was successful
     EXPECT_EQ(DecapReport::Signer_Certificate_Not_Found, decap_confirm.report);
+}
+
+// See TS 103 096-2 v1.3.1, section 5.2.1
+TEST_F(SecurityEntityTest, verify_message_protocol_version)
+{
+    auto secured_message = create_secured_message();
+    ASSERT_EQ(secured_message.protocol_version(), 2);
+}
+
+// See TS 103 096-2 v1.3.1, section 5.2.4.1
+TEST_F(SecurityEntityTest, verify_message_its_aid)
+{
+    auto secured_message = create_secured_message();
+    auto aid_header = secured_message.header_field(HeaderFieldType::Its_Aid);
+    ASSERT_EQ(boost::get<IntX>(*aid_header), itsAidCa);
+}
+
+// See TS 103 096-2 v1.3.1, section 5.2.4.3 + 5.2.4.5 + 5.2.4.6 + 5.2.4.7
+TEST_F(SecurityEntityTest, verify_message_signer_info)
+{
+    auto signer_info = [this](SecuredMessageV2& secured_message) -> SignerInfo {
+        auto signer_info = secured_message.header_field(HeaderFieldType::Signer_Info);
+
+        return boost::get<SignerInfo>(*signer_info);
+    };
+
+    // first message must be signed with certificate
+    auto secured_message = create_secured_message();
+    ASSERT_EQ(get_type(signer_info(secured_message)), SignerInfoType::Certificate);
+
+    // next messages must be signed with certificate digest, until one second is over or certificate has been requested
+    for (int i = 0; i < 5; i++) {
+        secured_message = create_secured_message();
+        ASSERT_EQ(get_type(signer_info(secured_message)), SignerInfoType::Certificate_Digest_With_SHA256);
+
+        // See TS 103 096-2 v1.3.1, section 5.2.2
+        ASSERT_EQ(
+            boost::get<HashedId8>(signer_info(secured_message)),
+            calculate_hash(certificate_provider->own_certificate())
+        );
+    }
+
+    // certificate has been requested by another party, send certificate
+    sign_header_policy.report_requested_certificate();
+    secured_message = create_secured_message();
+    ASSERT_EQ(get_type(signer_info(secured_message)), SignerInfoType::Certificate);
+
+    // next messages must be signed with certificate digest, until one second is over or certificate has been requested
+    for (int i = 0; i < 5; i++) {
+        secured_message = create_secured_message();
+        ASSERT_EQ(get_type(signer_info(secured_message)), SignerInfoType::Certificate_Digest_With_SHA256);
+    }
+
+    // certificate chain has been requested by another party, send certificate chain
+    sign_header_policy.report_requested_certificate_chain();
+    secured_message = create_secured_message();
+    ASSERT_EQ(get_type(signer_info(secured_message)), SignerInfoType::Certificate_Chain);
+
+    // next messages must be signed with certificate digest, until one second is over or certificate has been requested
+    for (int i = 0; i < 5; i++) {
+        secured_message = create_secured_message();
+        ASSERT_EQ(get_type(signer_info(secured_message)), SignerInfoType::Certificate_Digest_With_SHA256);
+    }
+
+    runtime.trigger(std::chrono::seconds(1));
+
+    // one second has passed, send certificate
+    sign_header_policy.report_requested_certificate();
+    secured_message = create_secured_message();
+    ASSERT_EQ(get_type(signer_info(secured_message)), SignerInfoType::Certificate);
+
+    // next messages must be signed with certificate digest, until one second is over or certificate has been requested
+    for (int i = 0; i < 5; i++) {
+        secured_message = create_secured_message();
+        ASSERT_EQ(get_type(signer_info(secured_message)), SignerInfoType::Certificate_Digest_With_SHA256);
+    }
 }
 
 // TODO add tests for Unsupported_Signer_Identifier_Type, Incompatible_Protocol

--- a/vanetza/security/tests/security_entity.cpp
+++ b/vanetza/security/tests/security_entity.cpp
@@ -223,7 +223,7 @@ TEST_F(SecurityEntityTest, verify_message_modified_certificate_subject_info)
     // verify message
     DecapConfirm decap_confirm = security.decapsulate_packet(DecapRequest { create_secured_message(certificate) });
     ASSERT_FALSE(decap_confirm.certificate_validity);
-    EXPECT_EQ(CertificateInvalidReason::UNKNOWN_SIGNER, decap_confirm.certificate_validity.reason());
+    EXPECT_EQ(CertificateInvalidReason::INVALID_SIGNER, decap_confirm.certificate_validity.reason());
 }
 
 TEST_F(SecurityEntityTest, verify_message_modified_certificate_subject_assurance)

--- a/vanetza/security/validity_restriction.hpp
+++ b/vanetza/security/validity_restriction.hpp
@@ -134,4 +134,3 @@ void serialize(OutputArchive&, const ValidityRestriction&);
 } // namespace vanetza
 
 #endif /* VALIDITY_RESTRICTION_HPP_LMCUHYLJ */
-

--- a/vanetza/security/verify_service.cpp
+++ b/vanetza/security/verify_service.cpp
@@ -172,6 +172,14 @@ VerifyService straight_verify_service(Runtime& rt, CertificateProvider& cert_pro
         boost::optional<Certificate> signer;
 
         for (auto& cert : possible_certificates) {
+            SubjectType subject_type = cert.subject_info.subject_type;
+
+            if (subject_type != SubjectType::Authorization_Ticket) {
+                confirm.report = VerificationReport::Invalid_Certificate;
+                confirm.certificate_validity = CertificateInvalidReason::INVALID_SIGNER;
+                return confirm;
+            }
+
             boost::optional<ecdsa256::PublicKey> public_key = get_public_key(cert);
 
             // public key could not be extracted
@@ -194,7 +202,7 @@ VerifyService straight_verify_service(Runtime& rt, CertificateProvider& cert_pro
             return confirm;
         }
 
-        // TODO check if Certificate_Chain is inconsistant
+        // TODO check if Certificate_Chain is inconsistent
         CertificateValidity cert_validity = certs.check_certificate(signer.get());
 
         // if certificate could not be verified return correct DecapReport

--- a/vanetza/security/verify_service.hpp
+++ b/vanetza/security/verify_service.hpp
@@ -4,8 +4,8 @@
 #include <boost/optional.hpp>
 #include <vanetza/common/byte_buffer.hpp>
 #include <vanetza/security/certificate.hpp>
-#include <vanetza/security/its_aid.hpp>
-#include <vanetza/security/secured_message.hpp>
+#include <vanetza/security/decap_confirm.hpp>
+#include <vanetza/security/decap_request.hpp>
 #include <functional>
 
 namespace vanetza
@@ -24,43 +24,10 @@ class CertificateProvider;
 class CertificateValidator;
 class SignHeaderPolicy;
 
-enum class VerificationReport
-{
-    Success,
-    False_Signature,
-    Invalid_Certificate,
-    Revoked_Certificate,
-    Inconsistant_Chain,
-    Invalid_Timestamp,
-    Duplicate_Message,
-    Invalid_Mobility_Data,
-    Unsigned_Message,
-    Signer_Certificate_Not_Found,
-    Unsupported_Signer_Identifier_Type,
-    Incompatible_Protocol
-};
-
-// mandatory parameters of SN-VERIFY.request (TS 102 723-8 V1.1.1)
-struct VerifyRequest
-{
-    VerifyRequest(const SecuredMessage& msg) : secured_message(msg) {}
-    const SecuredMessage& secured_message; /*< contains security header and payload */
-};
-
-// parameters of SN-VERIFY.confirm (TS 102 723-8 V1.1.1)
-struct VerifyConfirm
-{
-    VerificationReport report; // mandatory
-    IntX its_aid; // mandatory
-    ByteBuffer permissions; // mandatory
-    CertificateValidity certificate_validity; // non-standard extension
-    boost::optional<HashedId8> certificate_id; // optional
-};
-
 /**
  * Equivalent of SN-VERIFY service in TS 102 723-8 V1.1.1
  */
-using VerifyService = std::function<VerifyConfirm(VerifyRequest&&)>;
+using VerifyService = std::function<DecapConfirm(DecapRequest&)>;
 
 /**
  * Get verify service with basic certificate and signature checks
@@ -76,11 +43,10 @@ VerifyService straight_verify_service(Runtime&, CertificateProvider&, Certificat
 
 /**
  * Get insecure dummy verify service without any checks
- * \param report confirm report result
- * \param validity certificate validity result
+ * \param confirm confirm report result
  * \return callable verify service
  */
-VerifyService dummy_verify_service(VerificationReport report, CertificateValidity validity);
+VerifyService dummy_verify_service(DecapConfirm confirm);
 
 } // namespace security
 } // namespace vanetza


### PR DESCRIPTION
It now checks the validity restrictions of certificates in the trust store and applies rectangular and circular region restrictions. It fails closed if any other (currently unsupported) region restrictions are in place.

Additionally, this adds a couple of tests, most of which are ported from the ETSI test suite, which I'm not yet able to run.