### PR TITLE
security: Fix public key encoding on disk

### DIFF
--- a/tools/certify/commands/extract-public-key.cpp
+++ b/tools/certify/commands/extract-public-key.cpp
@@ -68,8 +68,15 @@ int ExtractPublicKeyCommand::execute()
 
     std::cout << "OK" << std::endl;
 
+    Uncompressed coordinates;
+    coordinates.x.assign(public_key.x.begin(), public_key.x.end());
+    coordinates.y.assign(public_key.y.begin(), public_key.y.end());
+
+    ecdsa_nistp256_with_sha256 public_key_etsi;
+    public_key_etsi.public_key = coordinates;
+
     std::cout << "Writing public key to '" << output << "'... ";
-    save_public_key_to_file(output, public_key);
+    save_public_key_to_file(output, public_key_etsi);
     std::cout << "OK" << std::endl;
 
     return 0;

--- a/tools/certify/commands/generate-ticket.cpp
+++ b/tools/certify/commands/generate-ticket.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <iostream>
 #include <stdexcept>
+#include <boost/variant/get.hpp>
 #include <cryptopp/cryptlib.h>
 #include <vanetza/common/clock.hpp>
 #include <vanetza/common/its_aid.hpp>
@@ -14,8 +15,6 @@
 #include <vanetza/security/subject_info.hpp>
 
 namespace po = boost::program_options;
-using namespace CryptoPP;
-using namespace vanetza;
 using namespace vanetza::security;
 
 bool GenerateTicketCommand::parse(const std::vector<std::string>& opts)
@@ -64,13 +63,25 @@ int GenerateTicketCommand::execute()
         auto subject_private_key = load_private_key_from_file(subject_key_path);
         subject_key = subject_private_key.public_key;
     } catch (CryptoPP::BERDecodeErr e) {
-        subject_key = load_public_key_from_file(subject_key_path);
+        auto subject_key_etsi = load_public_key_from_file(subject_key_path);
+        if (get_type(subject_key_etsi) != PublicKeyAlgorithm::Ecdsa_Nistp256_With_Sha256) {
+            std::cerr << "Wrong public key algorithm." << std::endl;
+            return 1;
+        }
+
+        auto subject_key_etsi_ecdsa = boost::get<ecdsa_nistp256_with_sha256>(subject_key_etsi);
+        if (get_type(subject_key_etsi_ecdsa.public_key) != EccPointType::Uncompressed) {
+            std::cerr << "Unsupported ECC point type, must be uncompressed.";
+            return 1;
+        }
+
+        subject_key = ecdsa256::create_public_key(boost::get<Uncompressed>(subject_key_etsi_ecdsa.public_key));
     }
     std::cout << "OK" << std::endl;
 
     auto sign_cert = load_certificate_from_file(sign_cert_path);
 
-    auto time_now = Clock::at(boost::posix_time::microsec_clock::universal_time());
+    auto time_now = vanetza::Clock::at(boost::posix_time::microsec_clock::universal_time());
 
     Certificate certificate;
 
@@ -83,13 +94,13 @@ int GenerateTicketCommand::execute()
     // see  ETSI EN 302 637-2 V1.3.1 (2014-09)
     ItsAidSsp certificate_ssp_ca;
     certificate_ssp_ca.its_aid = IntX(aid::CA);
-    certificate_ssp_ca.service_specific_permissions = ByteBuffer({ 1, 0x80, 0 }); // no special permissions
+    certificate_ssp_ca.service_specific_permissions = vanetza::ByteBuffer({ 1, 0, 0 }); // no special permissions
     certificate_ssp.push_back(certificate_ssp_ca);
 
     // see ETSI EN 302 637-3 V1.2.2 (2014-11)
     ItsAidSsp certificate_ssp_den;
     certificate_ssp_den.its_aid = IntX(aid::DEN);
-    certificate_ssp_den.service_specific_permissions = ByteBuffer({ 1, 0, 0, 0 }); // no special permissions
+    certificate_ssp_den.service_specific_permissions = vanetza::ByteBuffer({ 1, 0, 0, 0 }); // no special permissions
     certificate_ssp.push_back(certificate_ssp_den);
 
     certificate.signer_info = calculate_hash(sign_cert);
@@ -115,7 +126,7 @@ int GenerateTicketCommand::execute()
 
     std::cout << "Signing certificate... ";
 
-    ByteBuffer data_buffer = convert_for_signing(certificate);
+    auto data_buffer = convert_for_signing(certificate);
     certificate.signature = crypto_backend.sign_data(sign_key.private_key, data_buffer);
 
     std::cout << "OK" << std::endl;

--- a/vanetza/security/persistence.cpp
+++ b/vanetza/security/persistence.cpp
@@ -38,40 +38,25 @@ ecdsa256::KeyPair load_private_key_from_file(const std::string& key_path)
     return key_pair;
 }
 
-ecdsa256::PublicKey load_public_key_from_file(const std::string& key_path)
+PublicKey load_public_key_from_file(const std::string& key_path)
 {
-    EccPoint ecc_point;
+    PublicKey public_key;
 
     std::ifstream key_src;
     key_src.open(key_path, std::ios::in | std::ios::binary);
     vanetza::InputArchive key_archive(key_src, boost::archive::no_header);
-    deserialize(key_archive, ecc_point, PublicKeyAlgorithm::Ecdsa_Nistp256_With_Sha256);
+    deserialize(key_archive, public_key);
 
-    auto coordinates = boost::get<Uncompressed>(ecc_point);
-
-    ecdsa256::PublicKey pub;
-    if (coordinates.x.size() != pub.x.size() || coordinates.y.size() != pub.y.size()) {
-        throw std::runtime_error("Coordinate size mismatch");
-    }
-
-    std::copy_n(coordinates.x.begin(), pub.x.size(), pub.x.data());
-    std::copy_n(coordinates.y.begin(), pub.y.size(), pub.y.data());
-
-    return pub;
+    return public_key;
 }
 
-void save_public_key_to_file(const std::string& key_path, const ecdsa256::PublicKey& public_key)
+void save_public_key_to_file(const std::string& key_path, const PublicKey& public_key)
 {
-    Uncompressed coordinates;
-    coordinates.x.assign(public_key.x.begin(), public_key.x.end());
-    coordinates.y.assign(public_key.y.begin(), public_key.y.end());
-    EccPoint ecc_point = coordinates;
-
     std::ofstream dest;
     dest.open(key_path.c_str(), std::ios::out | std::ios::binary);
 
     OutputArchive archive(dest, boost::archive::no_header);
-    serialize(archive, ecc_point, PublicKeyAlgorithm::Ecdsa_Nistp256_With_Sha256);
+    serialize(archive, public_key);
 }
 
 Certificate load_certificate_from_file(const std::string& certificate_path)

--- a/vanetza/security/persistence.hpp
+++ b/vanetza/security/persistence.hpp
@@ -21,14 +21,14 @@ ecdsa256::KeyPair load_private_key_from_file(const std::string& key_path);
  * \param key_path file to load the key from
  * \return loaded key
  */
-ecdsa256::PublicKey load_public_key_from_file(const std::string& key_path);
+PublicKey load_public_key_from_file(const std::string& key_path);
 
 /**
  * \brief Saves a public key to a file
  * \param key_path file to save the key to
  * \param public_key key to save
  */
-void save_public_key_to_file(const std::string& key_path, const ecdsa256::PublicKey& public_key);
+void save_public_key_to_file(const std::string& key_path, const PublicKey& public_key);
 
 /**
  * \brief Loads a certificate from a file


### PR DESCRIPTION
Previously the EccPoint was encoded only, without the leading byte that specifies the key type. This first byte is necessary to encode a key as it's done in TS 103 097 and by other implementations that expose the public key.