### PR TITLE
Fix small mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This comprises the following protocols and features among others:
 * Security
 * Support for ASN.1 messages (Facilities) such as CAM and DENM
 
-Though originally designed to operate on ITS-G5 channels in a Vehicular Ad Hoc Network (VANET) using IEEE 802.11p, Vanetza and its components can be combined with other communication technologies as well, e.g. GeoNetworking over IP multicast.
+Though originally designed to operate on ITS-G5 channels in a Vehicular Ad Hoc Network (VANET) using IEEE 802.11p, Vanetza and its components can be combined with other communication technologies as well, e.g. GeoNetworking over Ethernet.
 
 # How to build
 


### PR DESCRIPTION
GeoNetworking is a layer 3 protocol just as IP. Socktap uses GeoNetworking over Ethernet, not over IP. There are no IP addresses involved.