### PR TITLE
Improve certify permissions

### DIFF
--- a/tools/certify/CMakeLists.txt
+++ b/tools/certify/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(certify
     commands/show-certificate.cpp
     main.cpp
     options.cpp
+    utils.cpp
 )
 
 set_target_properties(certify PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tools/certify/commands/generate-aa.cpp
+++ b/tools/certify/commands/generate-aa.cpp
@@ -1,10 +1,12 @@
 #include "generate-aa.hpp"
+#include "utils.hpp"
 #include <boost/program_options.hpp>
 #include <chrono>
 #include <iostream>
 #include <stdexcept>
 #include <boost/variant/get.hpp>
 #include <vanetza/common/clock.hpp>
+#include <vanetza/common/its_aid.hpp>
 #include <vanetza/security/backend_cryptopp.hpp>
 #include <vanetza/security/basic_elements.hpp>
 #include <vanetza/security/certificate.hpp>
@@ -12,6 +14,7 @@
 #include <vanetza/security/subject_attribute.hpp>
 #include <vanetza/security/subject_info.hpp>
 
+namespace aid = vanetza::aid;
 namespace po = boost::program_options;
 using namespace vanetza::security;
 
@@ -26,6 +29,8 @@ bool GenerateAaCommand::parse(const std::vector<std::string>& opts)
         ("subject-key", po::value<std::string>(&subject_key_path)->required(), "Private key file to issue the certificate for.")
         ("subject-name", po::value<std::string>(&subject_name)->default_value("Hello World Auth-CA"), "Subject name.")
         ("days", po::value<int>(&validity_days)->default_value(180), "Validity in days.")
+        ("cam-permissions", po::value<std::string>(&cam_permissions), "CAM permissions as binary string (e.g. '1111111111111100' to grant all SSPs)")
+        ("denm-permissions", po::value<std::string>(&cam_permissions), "DENM permissions as binary string (e.g. '000000000000000000000000' to grant no SSPs)")
     ;
 
     po::positional_options_description pos;
@@ -82,7 +87,36 @@ int GenerateAaCommand::execute()
 
     auto time_now = vanetza::Clock::at(boost::posix_time::microsec_clock::universal_time());
 
+    auto cam_ssps = vanetza::ByteBuffer({ 1, 0, 0 }); // no special permissions
+    auto denm_ssps = vanetza::ByteBuffer({ 1, 0, 0, 0 }); // no special permissions
+
+    if (cam_permissions.size()) {
+        permission_string_to_buffer(cam_permissions, cam_ssps);
+    }
+
+    if (denm_permissions.size()) {
+        permission_string_to_buffer(denm_permissions, denm_ssps);
+    }
+
     Certificate certificate;
+
+    std::list<IntX> certificate_aids;
+    certificate_aids.push_back(IntX(aid::CA));
+    certificate_aids.push_back(IntX(aid::DEN));
+
+    std::list<ItsAidSsp> certificate_ssp;
+
+    // see  ETSI EN 302 637-2 V1.3.1 (2014-09)
+    ItsAidSsp certificate_ssp_ca;
+    certificate_ssp_ca.its_aid = IntX(aid::CA);
+    certificate_ssp_ca.service_specific_permissions = cam_ssps;
+    certificate_ssp.push_back(certificate_ssp_ca);
+
+    // see ETSI EN 302 637-3 V1.2.2 (2014-11)
+    ItsAidSsp certificate_ssp_den;
+    certificate_ssp_den.its_aid = IntX(aid::DEN);
+    certificate_ssp_den.service_specific_permissions = denm_ssps;
+    certificate_ssp.push_back(certificate_ssp_den);
 
     certificate.signer_info = calculate_hash(sign_cert);
 
@@ -91,6 +125,8 @@ int GenerateAaCommand::execute()
     certificate.subject_info.subject_type = SubjectType::Authorization_Authority;
 
     certificate.subject_attributes.push_back(SubjectAssurance(0x00));
+    certificate.subject_attributes.push_back(certificate_ssp);
+    certificate.subject_attributes.push_back(certificate_aids);
 
     Uncompressed coordinates;
     coordinates.x.assign(subject_key.x.begin(), subject_key.x.end());

--- a/tools/certify/commands/generate-aa.hpp
+++ b/tools/certify/commands/generate-aa.hpp
@@ -16,8 +16,7 @@ private:
     std::string subject_key_path;
     std::string subject_name;
     int validity_days;
-    std::string cam_permissions;
-    std::string denm_permissions;
+    std::vector<unsigned> aids;
 };
 
 #endif /* CERTIFY_COMMANDS_GENERATE_AA_HPP */

--- a/tools/certify/commands/generate-aa.hpp
+++ b/tools/certify/commands/generate-aa.hpp
@@ -16,6 +16,8 @@ private:
     std::string subject_key_path;
     std::string subject_name;
     int validity_days;
+    std::string cam_permissions;
+    std::string denm_permissions;
 };
 
 #endif /* CERTIFY_COMMANDS_GENERATE_AA_HPP */

--- a/tools/certify/commands/generate-root.cpp
+++ b/tools/certify/commands/generate-root.cpp
@@ -1,5 +1,4 @@
 #include "generate-root.hpp"
-#include "utils.hpp"
 #include <boost/program_options.hpp>
 #include <chrono>
 #include <iostream>
@@ -26,8 +25,7 @@ bool GenerateRootCommand::parse(const std::vector<std::string>& opts)
         ("subject-key", po::value<std::string>(&subject_key_path)->required(), "Private key file.")
         ("subject-name", po::value<std::string>(&subject_name)->default_value("Hello World Root-CA"), "Subject name.")
         ("days", po::value<int>(&validity_days)->default_value(365), "Validity in days.")
-        ("cam-permissions", po::value<std::string>(&cam_permissions), "CAM permissions as binary string (e.g. '1111111111111100' to grant all SSPs)")
-        ("denm-permissions", po::value<std::string>(&cam_permissions), "DENM permissions as binary string (e.g. '000000000000000000000000' to grant no SSPs)")
+        ("aid", po::value<std::vector<unsigned> >(&aids)->multitoken(), "Allowed ITS-AIDs to restrict permissions, defaults to 36 (CA) and 37 (DEN) if empty.")
     ;
 
     po::positional_options_description pos;
@@ -63,37 +61,18 @@ int GenerateRootCommand::execute()
 
     auto time_now = vanetza::Clock::at(boost::posix_time::microsec_clock::universal_time());
 
-    auto cam_ssps = vanetza::ByteBuffer({ 1, 0, 0 }); // no special permissions
-    auto denm_ssps = vanetza::ByteBuffer({ 1, 0, 0, 0 }); // no special permissions
-
-    if (cam_permissions.size()) {
-        permission_string_to_buffer(cam_permissions, cam_ssps);
-    }
-
-    if (denm_permissions.size()) {
-        permission_string_to_buffer(denm_permissions, denm_ssps);
-    }
-
     // create certificate
     Certificate certificate;
-
     std::list<IntX> certificate_aids;
-    certificate_aids.push_back(IntX(aid::CA));
-    certificate_aids.push_back(IntX(aid::DEN));
 
-    std::list<ItsAidSsp> certificate_ssp;
-
-    // see  ETSI EN 302 637-2 V1.3.1 (2014-09)
-    ItsAidSsp certificate_ssp_ca;
-    certificate_ssp_ca.its_aid = IntX(aid::CA);
-    certificate_ssp_ca.service_specific_permissions = cam_ssps;
-    certificate_ssp.push_back(certificate_ssp_ca);
-
-    // see ETSI EN 302 637-3 V1.2.2 (2014-11)
-    ItsAidSsp certificate_ssp_den;
-    certificate_ssp_den.its_aid = IntX(aid::DEN);
-    certificate_ssp_den.service_specific_permissions = denm_ssps;
-    certificate_ssp.push_back(certificate_ssp_den);
+    if (aids.size()) {
+        for (unsigned aid : aids) {
+            certificate_aids.push_back(IntX(aid));
+        }
+    } else {
+        certificate_aids.push_back(IntX(aid::CA));
+        certificate_aids.push_back(IntX(aid::DEN));
+    }
 
     // section 6.1 in TS 103 097 v1.2.1
     certificate.signer_info = nullptr; /* self */
@@ -107,8 +86,6 @@ int GenerateRootCommand::execute()
 
     // section 6.6 in TS 103 097 v1.2.1 - levels currently undefined
     certificate.subject_attributes.push_back(SubjectAssurance(0x00));
-    certificate.subject_attributes.push_back(certificate_ssp);
-    certificate.subject_attributes.push_back(certificate_aids);
 
     // section 7.4.1 in TS 103 097 v1.2.1
     // set subject attributes

--- a/tools/certify/commands/generate-root.hpp
+++ b/tools/certify/commands/generate-root.hpp
@@ -14,8 +14,7 @@ private:
     std::string output;
     std::string subject_name;
     int validity_days;
-    std::string cam_permissions;
-    std::string denm_permissions;
+    std::vector<unsigned> aids;
 };
 
 #endif /* CERTIFY_COMMANDS_GENERATE_ROOT_HPP */

--- a/tools/certify/commands/generate-root.hpp
+++ b/tools/certify/commands/generate-root.hpp
@@ -14,6 +14,8 @@ private:
     std::string output;
     std::string subject_name;
     int validity_days;
+    std::string cam_permissions;
+    std::string denm_permissions;
 };
 
 #endif /* CERTIFY_COMMANDS_GENERATE_ROOT_HPP */

--- a/tools/certify/commands/generate-ticket.cpp
+++ b/tools/certify/commands/generate-ticket.cpp
@@ -98,11 +98,6 @@ int GenerateTicketCommand::execute()
     }
 
     Certificate certificate;
-
-    std::list<IntX> certificate_aids;
-    certificate_aids.push_back(IntX(aid::CA));
-    certificate_aids.push_back(IntX(aid::DEN));
-
     std::list<ItsAidSsp> certificate_ssp;
 
     // see  ETSI EN 302 637-2 V1.3.1 (2014-09)
@@ -121,7 +116,6 @@ int GenerateTicketCommand::execute()
     certificate.subject_info.subject_type = SubjectType::Authorization_Ticket;
     certificate.subject_attributes.push_back(SubjectAssurance(0x00));
     certificate.subject_attributes.push_back(certificate_ssp);
-    certificate.subject_attributes.push_back(certificate_aids);
 
     Uncompressed coordinates;
     coordinates.x.assign(subject_key.x.begin(), subject_key.x.end());

--- a/tools/certify/commands/generate-ticket.hpp
+++ b/tools/certify/commands/generate-ticket.hpp
@@ -15,6 +15,8 @@ private:
     std::string sign_cert_path;
     std::string subject_key_path;
     int validity_days;
+    std::string cam_permissions;
+    std::string denm_permissions;
 };
 
 #endif /* CERTIFY_COMMANDS_GENERATE_TICKET_HPP */

--- a/tools/certify/utils.cpp
+++ b/tools/certify/utils.cpp
@@ -1,0 +1,35 @@
+#include "utils.hpp"
+#include <cstdint>
+#include <stdexcept>
+#include <sstream>
+
+void permission_string_to_buffer(const std::string& in, vanetza::ByteBuffer& out)
+{
+    if (in.size() / 8 != out.size() - 1 /* version */) {
+        std::stringstream ss;
+        ss << "Size mismatch, expected " << (out.size() - 1) << " bytes encoded with one bit per byte.";
+        throw std::runtime_error(ss.str());
+    }
+
+    uint8_t byte = 0;
+    int index = 0;
+
+    for (auto it = in.begin(); it < in.end(); ++it) {
+        byte <<= 1;
+
+        if (*it == '0') {
+            byte = byte & 0xFE; // clear last bit
+        } else if (*it == '1') {
+            byte = byte | 1; // set last bit
+        } else {
+            throw std::runtime_error("Unexpected character in permissions, expected only '0' and '1'.");
+        }
+
+        if ((index + 1) % 8 == 0) {
+            out.at(1 /* version */ + (index / 8)) = byte;
+            byte = 0;
+        }
+
+        index++;
+    }
+}

--- a/tools/certify/utils.hpp
+++ b/tools/certify/utils.hpp
@@ -1,0 +1,9 @@
+#ifndef CERTIFY_UTILS_HPP
+#define CERTIFY_UTILS_HPP
+
+#include <vanetza/common/byte_buffer.hpp>
+#include <string>
+
+void permission_string_to_buffer(const std::string&, vanetza::ByteBuffer&);
+
+#endif /* CERTIFY_UTILS_HPP */


### PR DESCRIPTION
Permissions can now be specified as command line arguments. Additionally, CA certificates also contain permissions now.