### PR TITLE
Ensure correct order of certificate elements

### DIFF
--- a/tools/certify/commands/generate-aa.cpp
+++ b/tools/certify/commands/generate-aa.cpp
@@ -109,6 +109,7 @@ int GenerateAaCommand::execute()
 
     std::cout << "Signing certificate... ";
 
+    sort(certificate);
     auto data_buffer = convert_for_signing(certificate);
     certificate.signature = crypto_backend.sign_data(sign_key.private_key, data_buffer);
 

--- a/tools/certify/commands/generate-root.cpp
+++ b/tools/certify/commands/generate-root.cpp
@@ -97,7 +97,7 @@ int GenerateRootCommand::execute()
 
     std::cout << "Signing certificate... ";
 
-    // set signature
+    sort(certificate);
     vanetza::ByteBuffer data_buffer = convert_for_signing(certificate);
     certificate.signature = crypto_backend.sign_data(subject_key.private_key, data_buffer);
 

--- a/tools/certify/commands/generate-ticket.cpp
+++ b/tools/certify/commands/generate-ticket.cpp
@@ -127,6 +127,7 @@ int GenerateTicketCommand::execute()
 
     std::cout << "Signing certificate... ";
 
+    sort(certificate);
     auto data_buffer = convert_for_signing(certificate);
     certificate.signature = crypto_backend.sign_data(sign_key.private_key, data_buffer);
 

--- a/vanetza/security/certificate.cpp
+++ b/vanetza/security/certificate.cpp
@@ -80,6 +80,27 @@ ByteBuffer convert_for_signing(const Certificate& cert)
     return buf;
 }
 
+void sort(Certificate& cert)
+{
+    cert.subject_attributes.sort([](const SubjectAttribute& a, const SubjectAttribute& b) {
+        const SubjectAttributeType type_a = get_type(a);
+        const SubjectAttributeType type_b = get_type(b);
+
+        // all fields must be encoded in ascending order
+        using enum_int = std::underlying_type<SubjectAttributeType>::type;
+        return static_cast<enum_int>(type_a) < static_cast<enum_int>(type_b);
+    });
+
+    cert.validity_restriction.sort([](const ValidityRestriction& a, const ValidityRestriction& b) {
+        const ValidityRestrictionType type_a = get_type(a);
+        const ValidityRestrictionType type_b = get_type(b);
+
+        // all fields must be encoded in ascending order
+        using enum_int = std::underlying_type<ValidityRestrictionType>::type;
+        return static_cast<enum_int>(type_a) < static_cast<enum_int>(type_b);
+    });
+}
+
 boost::optional<Uncompressed> get_uncompressed_public_key(const Certificate& cert)
 {
     boost::optional<Uncompressed> public_key_coordinates;

--- a/vanetza/security/certificate.hpp
+++ b/vanetza/security/certificate.hpp
@@ -116,6 +116,13 @@ size_t deserialize(InputArchive&, Certificate&);
 ByteBuffer convert_for_signing(const Certificate&);
 
 /**
+ * \brief Sort lists in the certificate to be in the correct order for serialization
+ *
+ * \param cert certificate to sort
+ */
+void sort(Certificate& certificate);
+
+/**
  * \brief Extract public key from certificate
  * \param cert Certificate
  * \return Uncompressed public key (if available)

--- a/vanetza/security/naive_certificate_provider.cpp
+++ b/vanetza/security/naive_certificate_provider.cpp
@@ -115,6 +115,8 @@ Certificate NaiveCertificateProvider::generate_authorization_ticket()
 
 void NaiveCertificateProvider::sign_authorization_ticket(Certificate& certificate)
 {
+    sort(certificate);
+
     ByteBuffer data_buffer = convert_for_signing(certificate);
     certificate.signature = m_crypto_backend.sign_data(aa_key_pair().private_key, data_buffer);
 }
@@ -156,6 +158,8 @@ Certificate NaiveCertificateProvider::generate_aa_certificate(const std::string&
     start_and_end.start_validity = convert_time32(m_time_now - std::chrono::hours(1));
     start_and_end.end_validity = convert_time32(m_time_now + std::chrono::hours(23));
     certificate.validity_restriction.push_back(start_and_end);
+
+    sort(certificate);
 
     // set signature
     ByteBuffer data_buffer = convert_for_signing(certificate);
@@ -201,6 +205,8 @@ Certificate NaiveCertificateProvider::generate_root_certificate(const std::strin
     start_and_end.start_validity = convert_time32(m_time_now - std::chrono::hours(1));
     start_and_end.end_validity = convert_time32(m_time_now + std::chrono::hours(365 * 24));
     certificate.validity_restriction.push_back(start_and_end);
+
+    sort(certificate);
 
     // set signature
     ByteBuffer data_buffer = convert_for_signing(certificate);


### PR DESCRIPTION
They must be encoded in ascending order. Security profiles are allowed to override this order, but no defined security profile does that.