### PR TITLE
Fix header serialization order

### DIFF
--- a/vanetza/security/sign_service.cpp
+++ b/vanetza/security/sign_service.cpp
@@ -76,10 +76,18 @@ std::list<HeaderField> SignHeaderPolicy::prepare_header(const SignRequest& reque
         const HeaderFieldType type_a = get_type(a);
         const HeaderFieldType type_b = get_type(b);
 
+        // this shouldn't happen, as every header field should be present only once
+        if (type_a == type_b) {
+            return false; // a >= b
+        }
+
         // signer_info must be encoded first in all profiles
         if (type_a == HeaderFieldType::Signer_Info) {
-            // return false if both are signer_info fields
-            return type_b != HeaderFieldType::Signer_Info;
+            return true; // a < b
+        }
+
+        if (type_b == HeaderFieldType::Signer_Info) {
+            return false; // a >= b
         }
 
         // all other fields must be encoded in ascending order

--- a/vanetza/security/tests/security_entity.cpp
+++ b/vanetza/security/tests/security_entity.cpp
@@ -142,6 +142,18 @@ TEST_F(SecurityEntityTest, signature_is_ecdsa)
     EXPECT_EQ(PublicKeyAlgorithm::Ecdsa_Nistp256_With_Sha256, signature_type);
 }
 
+TEST_F(SecurityEntityTest, signer_info_is_encoded_first)
+{
+    auto message = create_secured_message();
+    EXPECT_EQ(HeaderFieldType::Signer_Info, get_type(message.header_fields.front()));
+
+    // Creates an additional header field that results in a difference in the sorting algorithm
+    sign_header_policy.report_unknown_certificate(HashedId8({ 0, 0, 0, 0, 0, 0, 0, 0 }));
+
+    message = create_secured_message();
+    EXPECT_EQ(HeaderFieldType::Signer_Info, get_type(message.header_fields.front()));
+}
+
 TEST_F(SecurityEntityTest, expected_header_field_size)
 {
     EncapConfirm confirm = security.encapsulate_packet(create_encap_request());


### PR DESCRIPTION
This is a follow-up PR on #40. A unit test is provided first to show that the current code isn't enough to ensure the correct order.