### PR TITLE
security: Fix chain order

### DIFF
--- a/vanetza/security/certificate_provider.hpp
+++ b/vanetza/security/certificate_provider.hpp
@@ -20,7 +20,7 @@ public:
     virtual const Certificate& own_certificate() = 0;
 
     /**
-     * Get own certificate chain, excluding the leaf certificate and root CA
+     * Get own certificate chain in root CA → AA → AT order, excluding the AT and root certificate
      * \return own certificate chain
      */
     virtual std::list<Certificate> own_chain() = 0;

--- a/vanetza/security/sign_service.cpp
+++ b/vanetza/security/sign_service.cpp
@@ -47,8 +47,8 @@ std::list<HeaderField> SignHeaderPolicy::prepare_header(const SignRequest& reque
         // section 7.1 in TS 103 097 v1.2.1
         if (m_chain_requested) {
             std::list<Certificate> full_chain;
-            full_chain.push_back(certificate_provider.own_certificate());
             full_chain.splice(full_chain.end(), certificate_provider.own_chain());
+            full_chain.push_back(certificate_provider.own_certificate());
             header_fields.push_back(SignerInfo { std::move(full_chain) });
             m_cam_next_certificate = m_time_now + std::chrono::seconds(1);
         } else if (m_time_now < m_cam_next_certificate && !m_cert_requested) {

--- a/vanetza/security/verify_service.cpp
+++ b/vanetza/security/verify_service.cpp
@@ -118,8 +118,8 @@ VerifyService straight_verify_service(Runtime& rt, CertificateProvider& cert_pro
                         confirm.report = VerificationReport::Signer_Certificate_Not_Found;
                         return confirm;
                     }
-                    // pre-check chain certificates in reverse order, otherwise they're not available for the ticket check
-                    for (auto& cert : boost::adaptors::reverse(chain)) {
+                    // pre-check chain certificates, otherwise they're not available for the ticket check
+                    for (auto& cert : chain) {
                         if (cert.subject_info.subject_type == SubjectType::Authorization_Authority) {
                             CertificateValidity validity = certs.check_certificate(cert);
                             if (validity) {
@@ -127,8 +127,9 @@ VerifyService straight_verify_service(Runtime& rt, CertificateProvider& cert_pro
                             }
                         }
                     }
-                    signer_hash = calculate_hash(chain.front());
-                    possible_certificates.push_back(chain.front());
+                    // last certificate must be the authorization ticket
+                    signer_hash = calculate_hash(chain.back());
+                    possible_certificates.push_back(chain.back());
                 }
                     break;
                 default:


### PR DESCRIPTION
This fixes the certificate order in case a certificate chain is sent or received. See TS 103 097 v1.2.1, section 4.2.10.