### PR TITLE
Check permissions during verification

### DIFF
--- a/vanetza/btp/data_indication.cpp
+++ b/vanetza/btp/data_indication.cpp
@@ -15,6 +15,8 @@ DataIndication::DataIndication(const geonet::DataIndication& ind, const HeaderA&
     source_port(btp.source_port),
     destination_port(btp.destination_port),
     destination(ind.destination),
+    its_aid(ind.its_aid),
+    permissions(ind.permissions),
     source_position(ind.source_position),
     traffic_class(ind.traffic_class),
     remaining_packet_lifetime(ind.remaining_packet_lifetime)
@@ -25,6 +27,8 @@ DataIndication::DataIndication(const geonet::DataIndication& ind, const HeaderB&
     destination_port(btp.destination_port),
     destination_port_info(btp.destination_port_info),
     destination(ind.destination),
+    its_aid(ind.its_aid),
+    permissions(ind.permissions),
     source_position(ind.source_position),
     traffic_class(ind.traffic_class),
     remaining_packet_lifetime(ind.remaining_packet_lifetime)

--- a/vanetza/btp/data_indication.hpp
+++ b/vanetza/btp/data_indication.hpp
@@ -26,6 +26,8 @@ struct DataIndication
     port_type destination_port;
     boost::optional<decltype(HeaderB::destination_port_info)> destination_port_info;
     decltype(geonet::DataIndication::destination) destination;
+    decltype(geonet::DataIndication::its_aid) its_aid;
+    decltype(geonet::DataIndication::permissions) permissions;
     geonet::ShortPositionVector source_position;
     geonet::TrafficClass traffic_class;
     boost::optional<geonet::Lifetime> remaining_packet_lifetime;

--- a/vanetza/common/its_aid.hpp
+++ b/vanetza/common/its_aid.hpp
@@ -23,9 +23,9 @@ constexpr ItsAid RLT = 138;
 constexpr ItsAid IVI = 139;
 constexpr ItsAid TLC = 140;
 constexpr ItsAid GN_MGMT = 141;
+constexpr ItsAid IPV6_ROUTING = 270549118;
 
 } // namespace aid
 } // namespace vanetza
 
 #endif /* ITS_AID_HPP_URKJ51RA */
-

--- a/vanetza/geonet/data_indication.hpp
+++ b/vanetza/geonet/data_indication.hpp
@@ -1,6 +1,8 @@
 #ifndef DATA_INDICATION_HPP_DOJK9Q8T
 #define DATA_INDICATION_HPP_DOJK9Q8T
 
+#include <vanetza/common/byte_buffer.hpp>
+#include <vanetza/common/its_aid.hpp>
 #include <vanetza/geonet/destination_variant.hpp>
 #include <vanetza/geonet/interface.hpp>
 #include <vanetza/geonet/position_vector.hpp>
@@ -19,7 +21,9 @@ struct DataIndication
     DestinationVariant destination;
     ShortPositionVector source_position;
     security::DecapReport security_report;
-    // TODO: certificate id and permissions are missing (optional)
+    boost::optional<ItsAid> its_aid;
+    boost::optional<ByteBuffer> permissions;
+    // TODO: certificate id is missing (optional)
     TrafficClass traffic_class;
     boost::optional<Lifetime> remaining_packet_lifetime;
     boost::optional<unsigned> remaining_hop_limit;
@@ -29,4 +33,3 @@ struct DataIndication
 } // namespace vanetza
 
 #endif /* DATA_INDICATION_HPP_DOJK9Q8T */
-

--- a/vanetza/geonet/router.cpp
+++ b/vanetza/geonet/router.cpp
@@ -466,6 +466,8 @@ void Router::indicate_secured(IndicationContextBasic& ctx, const BasicHeader& ba
         using namespace vanetza::security;
         DecapConfirm decap_confirm = m_security_entity->decapsulate_packet(DecapRequest(*secured_message));
         ctx.service_primitive().security_report = decap_confirm.report;
+        ctx.service_primitive().its_aid = decap_confirm.its_aid;
+        ctx.service_primitive().permissions = decap_confirm.permissions;
         secured_payload_visitor visitor(*this, ctx, basic);
 
         // check whether the received packet is valid

--- a/vanetza/geonet/tests/router_indicate.cpp
+++ b/vanetza/geonet/tests/router_indicate.cpp
@@ -163,6 +163,7 @@ TEST_F(RouterIndicate, shb_secured_equal_payload)
 
     // check if packet was not discarded
     ASSERT_NE(nullptr, ind_ifc.m_last_packet.get());
+    ASSERT_TRUE(ind_ifc.m_last_indication);
     // prepare a packet to check it's payload
     CohesivePacket* received_payload_ptr = boost::get<CohesivePacket>(ind_ifc.m_last_packet.get());
     ASSERT_NE(nullptr, received_payload_ptr);
@@ -171,6 +172,11 @@ TEST_F(RouterIndicate, shb_secured_equal_payload)
     const ByteBuffer received_payload = ByteBuffer(received_payload_range.begin(), received_payload_range.end());
     // check payload
     EXPECT_EQ(send_payload, received_payload);
+    // check permissions are exposed correctly, these are set by NaiveCertificateProvider for the aid::CA
+    ASSERT_TRUE(ind_ifc.m_last_indication.get().its_aid);
+    ASSERT_TRUE(ind_ifc.m_last_indication.get().permissions);
+    EXPECT_EQ(ind_ifc.m_last_indication.get().its_aid.get(), aid::CA);
+    EXPECT_EQ(ind_ifc.m_last_indication.get().permissions.get(), ByteBuffer({ 1, 0, 0 }));
 }
 
 TEST_F(RouterIndicate, shb_secured_hook_its_protocol_version)

--- a/vanetza/geonet/tests/routing.cpp
+++ b/vanetza/geonet/tests/routing.cpp
@@ -127,7 +127,7 @@ TEST_P(Routing, advanced_forwarding_source_inside_destination)
  */
 TEST_P(Routing, advanced_forwarding_receiver_inside_destination_cbf)
 {
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.destination = circle_dest_area(5.0_m, 2.0_m, 0.0_m);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     auto confirm = net.get_router(cars[1])->request(gbc_request, create_packet());
@@ -179,7 +179,7 @@ TEST_P(Routing, advanced_forwarding_receiver_inside_destination_cbf)
  */
 TEST_P(Routing, advanced_forwarding_max_counter_exceeded)
 {
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.destination = circle_dest_area(2.0_m, 2.0_m, 0.0_m);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     auto confirm = net.get_router(cars[0])->request(gbc_request, create_packet());
@@ -223,7 +223,7 @@ TEST_P(Routing, advanced_forwarding_avoid_double_broadcast)
     ASSERT_EQ(0, car1_ifc.counter);
     ASSERT_FALSE(car1_cbf.find(Address { cars[0] }, SequenceNumber(0)));
 
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.destination = circle_dest_area(1.0_m, 2.0_m, 0.0_m);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     auto confirm = net.get_router(cars[0])->request(gbc_request, create_packet());
@@ -257,7 +257,7 @@ TEST_P(Routing, advanced_forwarding_inside_sectorial_area)
 {
     EXPECT_FALSE(net.get_router(cars[5])->outside_sectorial_contention_area(cars[0], cars[2]));
 
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.destination = circle_dest_area(7.0_m, 0.0_m, 0.0_m);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     auto confirm = net.get_router(cars[0])->request(gbc_request, create_packet());
@@ -295,7 +295,7 @@ TEST_P(Routing, advanced_forwarding_outside_sectorial_area)
     net.reset_counters();
     EXPECT_TRUE(net.get_router(cars[5])->outside_sectorial_contention_area(cars[0], cars[2]));
 
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.destination = circle_dest_area(7.0_m, 0.0_m, 0.0_m);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     auto confirm = net.get_router(cars[0])->request(gbc_request, create_packet());
@@ -332,7 +332,7 @@ TEST_P(Routing, advanced_routing_distinct_sender_sectorial_area)
 {
     EXPECT_FALSE(net.get_router(cars[5])->outside_sectorial_contention_area(cars[2], cars[0]));
 
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.destination = circle_dest_area(4.5_m, 2.0_m, 0.0_m);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     auto confirm = net.get_router(cars[1])->request(gbc_request, create_packet());
@@ -366,7 +366,7 @@ TEST_P(Routing, advanced_routing_distinct_sender_sectorial_area)
  */
 TEST_P(Routing, greedy_forwarding_unicast)
 {
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.destination = circle_dest_area(1.0_m, 2.0_m, 2.0_m);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     auto confirm = net.get_router(cars[0])->request(gbc_request, create_packet());
@@ -404,7 +404,7 @@ TEST_P(Routing, greedy_forwarding_unicast)
 TEST_P(Routing, greedy_forwarding_broadcast)
 {
     net.get_mib().itsGnDefaultTrafficClass.store_carry_forward(false);
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     gbc_request.destination = circle_dest_area(1.0_m, -2.0_m, 0.0_m);
     auto confirm = net.get_router(cars[0])->request(gbc_request, create_packet());
@@ -422,7 +422,7 @@ TEST_P(Routing, greedy_forwarding_broadcast)
 TEST_P(Routing, greedy_forwarding_scf)
 {
     net.get_mib().itsGnDefaultTrafficClass.store_carry_forward(true);
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     gbc_request.destination = circle_dest_area(1.0_m, -2.0_m, 0.0_m);
     auto confirm = net.get_router(cars[0])->request(gbc_request, create_packet());
@@ -435,7 +435,7 @@ TEST_P(Routing, greedy_forwarding_scf)
 
     // move one station to become a forwarder and propagate its new position via SHB
     net.set_position(cars[5], CartesianPosition(-1.0_m, 0.0_m));
-    ShbDataRequest shb_request(net.get_mib());
+    ShbDataRequest shb_request(net.get_mib(), aid::IPV6_ROUTING);
     shb_request.upper_protocol = UpperProtocol::IPv6;
     ASSERT_TRUE(net.get_router(cars[5])->request(shb_request, create_packet()).accepted());
 
@@ -460,7 +460,7 @@ TEST_P(Routing, greedy_forwarding_scf)
  */
 TEST_P(Routing, forwarding_selection_discard)
 {
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.destination = circle_dest_area(3.0_m, 0.0_m, 0.0_m);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     auto confirm = net.get_router(cars[0])->request(gbc_request, create_packet());
@@ -497,7 +497,7 @@ TEST_P(Routing, forwarding_selection_inaccurate_position)
     net.advance_time(std::chrono::seconds(4));
     net.reset_counters();
 
-    GbcDataRequest gbc_request(net.get_mib());
+    GbcDataRequest gbc_request(net.get_mib(), aid::IPV6_ROUTING);
     gbc_request.destination = circle_dest_area(3.0_m, 0.0_m, 0.0_m);
     gbc_request.upper_protocol = UpperProtocol::IPv6;
     auto confirm = net.get_router(cars[0])->request(gbc_request, create_packet());

--- a/vanetza/security/CMakeLists.txt
+++ b/vanetza/security/CMakeLists.txt
@@ -5,6 +5,7 @@ add_vanetza_component(security
     cam_ssp.cpp
     certificate.cpp
     certificate_cache.cpp
+    certificate_modifications.cpp
     default_certificate_validator.cpp
     ecc_point.cpp
     ecdsa256.cpp

--- a/vanetza/security/certificate.hpp
+++ b/vanetza/security/certificate.hpp
@@ -41,6 +41,7 @@ enum class CertificateInvalidReason
     INVALID_NAME,
     EXCESSIVE_CHAIN_LENGTH,
     OFF_REGION,
+    INCONSISTENT_WITH_SIGNER,
 };
 
 class CertificateValidity

--- a/vanetza/security/certificate_modifications.cpp
+++ b/vanetza/security/certificate_modifications.cpp
@@ -1,0 +1,58 @@
+#include <vanetza/security/certificate_modifications.hpp>
+#include <boost/variant/get.hpp>
+
+namespace vanetza
+{
+namespace security
+{
+
+void certificate_remove_attribute(Certificate& cert, const SubjectAttributeType& type)
+{
+    for (auto it = cert.subject_attributes.begin(); it != cert.subject_attributes.end(); ++it) {
+        if (get_type(*it) == type) {
+            it = cert.subject_attributes.erase(it);
+        }
+    }
+}
+
+void certificate_remove_restriction(Certificate& cert, const ValidityRestrictionType& type)
+{
+    for (auto it = cert.validity_restriction.begin(); it != cert.validity_restriction.end(); ++it) {
+        if (get_type(*it) == type) {
+            it = cert.validity_restriction.erase(it);
+        }
+    }
+}
+
+void certificate_add_permission(Certificate& cert, const ItsAid aid)
+{
+    for (auto& item : cert.subject_attributes) {
+        if (get_type(item) == SubjectAttributeType::Its_Aid_List) {
+            auto& list = boost::get<std::list<IntX> >(item);
+            list.push_back(IntX(aid));
+
+            return;
+        }
+    }
+
+    cert.subject_attributes.push_back(std::list<IntX>({ IntX(aid) }));
+}
+
+void certificate_add_permission(Certificate& cert, const ItsAid aid, const ByteBuffer ssp)
+{
+    ItsAidSsp permission({ IntX(aid), ssp });
+
+    for (auto& item : cert.subject_attributes) {
+        if (get_type(item) == SubjectAttributeType::Its_Aid_Ssp_List) {
+            auto& list = boost::get<std::list<ItsAidSsp> >(item);
+            list.push_back(permission);
+
+            return;
+        }
+    }
+
+    cert.subject_attributes.push_back(std::list<ItsAidSsp>({ permission }));
+}
+
+} // namespace security
+} // namespace vanetza

--- a/vanetza/security/certificate_modifications.hpp
+++ b/vanetza/security/certificate_modifications.hpp
@@ -1,0 +1,23 @@
+#ifndef CERTIFICATE_MODIFICATIONS_HPP
+#define CERTIFICATE_MODIFICATIONS_HPP
+
+#include <vanetza/common/its_aid.hpp>
+#include <vanetza/security/certificate.hpp>
+
+namespace vanetza
+{
+namespace security
+{
+
+void certificate_remove_attribute(Certificate&, const SubjectAttributeType&);
+
+void certificate_remove_restriction(Certificate&, const ValidityRestrictionType&);
+
+void certificate_add_permission(Certificate&, const ItsAid aid);
+
+void certificate_add_permission(Certificate&, const ItsAid aid, const ByteBuffer ssp);
+
+} // namespace security
+} // namespace vanetza
+
+#endif // CERTIFICATE_MODIFICATIONS_HPP

--- a/vanetza/security/decap_confirm.hpp
+++ b/vanetza/security/decap_confirm.hpp
@@ -1,6 +1,7 @@
 #ifndef DECAP_CONFIRM_HPP
 #define DECAP_CONFIRM_HPP
 
+#include <vanetza/common/its_aid.hpp>
 #include <vanetza/security/certificate.hpp>
 #include <vanetza/security/payload.hpp>
 #include <boost/optional.hpp>
@@ -45,7 +46,8 @@ struct DecapConfirm
     DecapReport report; // mandatory
     CertificateValidity certificate_validity; // non-standard extension
     boost::optional<HashedId8> certificate_id; // optional
-    // member field 'permissions' currently not used; optional
+    ItsAid its_aid; // mandatory
+    ByteBuffer permissions; // mandatory
 };
 
 } // namespace security

--- a/vanetza/security/naive_certificate_provider.cpp
+++ b/vanetza/security/naive_certificate_provider.cpp
@@ -1,5 +1,6 @@
 #include <vanetza/common/its_aid.hpp>
 #include <vanetza/security/basic_elements.hpp>
+#include <vanetza/security/certificate_modifications.hpp>
 #include <vanetza/security/ecc_point.hpp>
 #include <vanetza/security/naive_certificate_provider.hpp>
 #include <vanetza/security/payload.hpp>
@@ -89,22 +90,9 @@ Certificate NaiveCertificateProvider::generate_authorization_ticket()
     // set assurance level
     certificate.subject_attributes.push_back(SubjectAssurance(0x00));
 
-    std::list<ItsAidSsp> permissions;
-
-    ItsAidSsp ca_permissions;
-    ca_permissions.its_aid = IntX(aid::CA);
-    ca_permissions.service_specific_permissions = ByteBuffer({ 1, 0, 0 });
-    permissions.push_back(ca_permissions);
-
-    ItsAidSsp gn_permissions; // required for beacons in tests
-    gn_permissions.its_aid = IntX(aid::GN_MGMT);
-    permissions.push_back(gn_permissions);
-
-    ItsAidSsp ip_permissions; // required for routing tests
-    ip_permissions.its_aid = IntX(aid::IPV6_ROUTING);
-    permissions.push_back(ip_permissions);
-
-    certificate.subject_attributes.push_back(permissions);
+    certificate_add_permission(certificate, aid::CA, ByteBuffer({ 1, 0, 0 }));
+    certificate_add_permission(certificate, aid::GN_MGMT, ByteBuffer({})); // required for beacons
+    certificate_add_permission(certificate, aid::IPV6_ROUTING, ByteBuffer({})); // required for routing tests
 
     // section 7.4.1 in TS 103 097 v1.2.1
     // set subject attributes
@@ -155,11 +143,9 @@ Certificate NaiveCertificateProvider::generate_aa_certificate(const std::string&
     // section 6.6 in TS 103 097 v1.2.1 - levels currently undefined
     certificate.subject_attributes.push_back(SubjectAssurance(0x00));
 
-    std::list<IntX> permissions;
-    permissions.push_back(IntX(aid::CA));
-    permissions.push_back(IntX(aid::GN_MGMT)); // required for beacons in tests
-    permissions.push_back(IntX(aid::IPV6_ROUTING)); // required for routing tests
-    certificate.subject_attributes.push_back(permissions);
+    certificate_add_permission(certificate, aid::CA);
+    certificate_add_permission(certificate, aid::GN_MGMT); // required for beacons
+    certificate_add_permission(certificate, aid::IPV6_ROUTING); // required for routing tests
 
     // section 7.4.1 in TS 103 097 v1.2.1
     // set subject attributes
@@ -206,11 +192,9 @@ Certificate NaiveCertificateProvider::generate_root_certificate(const std::strin
     // section 6.6 in TS 103 097 v1.2.1 - levels currently undefined
     certificate.subject_attributes.push_back(SubjectAssurance(0x00));
 
-    std::list<IntX> permissions;
-    permissions.push_back(IntX(aid::CA));
-    permissions.push_back(IntX(aid::GN_MGMT)); // required for beacons in tests
-    permissions.push_back(IntX(aid::IPV6_ROUTING)); // required for routing tests
-    certificate.subject_attributes.push_back(permissions);
+    certificate_add_permission(certificate, aid::CA);
+    certificate_add_permission(certificate, aid::GN_MGMT); // required for beacons
+    certificate_add_permission(certificate, aid::IPV6_ROUTING); // required for routing tests
 
     // section 7.4.1 in TS 103 097 v1.2.1
     // set subject attributes

--- a/vanetza/security/naive_certificate_provider.cpp
+++ b/vanetza/security/naive_certificate_provider.cpp
@@ -1,3 +1,4 @@
+#include <vanetza/common/its_aid.hpp>
 #include <vanetza/security/basic_elements.hpp>
 #include <vanetza/security/ecc_point.hpp>
 #include <vanetza/security/naive_certificate_provider.hpp>
@@ -88,6 +89,23 @@ Certificate NaiveCertificateProvider::generate_authorization_ticket()
     // set assurance level
     certificate.subject_attributes.push_back(SubjectAssurance(0x00));
 
+    std::list<ItsAidSsp> permissions;
+
+    ItsAidSsp ca_permissions;
+    ca_permissions.its_aid = IntX(aid::CA);
+    ca_permissions.service_specific_permissions = ByteBuffer({ 1, 0, 0 });
+    permissions.push_back(ca_permissions);
+
+    ItsAidSsp gn_permissions; // required for beacons in tests
+    gn_permissions.its_aid = IntX(aid::GN_MGMT);
+    permissions.push_back(gn_permissions);
+
+    ItsAidSsp ip_permissions; // required for routing tests
+    ip_permissions.its_aid = IntX(aid::IPV6_ROUTING);
+    permissions.push_back(ip_permissions);
+
+    certificate.subject_attributes.push_back(permissions);
+
     // section 7.4.1 in TS 103 097 v1.2.1
     // set subject attributes
     // set the verification_key
@@ -137,6 +155,12 @@ Certificate NaiveCertificateProvider::generate_aa_certificate(const std::string&
     // section 6.6 in TS 103 097 v1.2.1 - levels currently undefined
     certificate.subject_attributes.push_back(SubjectAssurance(0x00));
 
+    std::list<IntX> permissions;
+    permissions.push_back(IntX(aid::CA));
+    permissions.push_back(IntX(aid::GN_MGMT)); // required for beacons in tests
+    permissions.push_back(IntX(aid::IPV6_ROUTING)); // required for routing tests
+    certificate.subject_attributes.push_back(permissions);
+
     // section 7.4.1 in TS 103 097 v1.2.1
     // set subject attributes
     // set the verification_key
@@ -181,6 +205,12 @@ Certificate NaiveCertificateProvider::generate_root_certificate(const std::strin
 
     // section 6.6 in TS 103 097 v1.2.1 - levels currently undefined
     certificate.subject_attributes.push_back(SubjectAssurance(0x00));
+
+    std::list<IntX> permissions;
+    permissions.push_back(IntX(aid::CA));
+    permissions.push_back(IntX(aid::GN_MGMT)); // required for beacons in tests
+    permissions.push_back(IntX(aid::IPV6_ROUTING)); // required for routing tests
+    certificate.subject_attributes.push_back(permissions);
 
     // section 7.4.1 in TS 103 097 v1.2.1
     // set subject attributes

--- a/vanetza/security/security_entity.cpp
+++ b/vanetza/security/security_entity.cpp
@@ -42,6 +42,8 @@ DecapConfirm SecurityEntity::decapsulate_packet(DecapRequest&& decap_request)
     decap_confirm.plaintext_payload = std::move(decap_request.sec_packet.payload.data);
     decap_confirm.report = static_cast<DecapReport>(verify_confirm.report);
     decap_confirm.certificate_validity = verify_confirm.certificate_validity;
+    decap_confirm.its_aid = verify_confirm.its_aid;
+    decap_confirm.permissions = verify_confirm.permissions;
     return decap_confirm;
 }
 

--- a/vanetza/security/tests/default_certificate_validator.cpp
+++ b/vanetza/security/tests/default_certificate_validator.cpp
@@ -2,6 +2,7 @@
 #include <vanetza/common/runtime.hpp>
 #include <vanetza/common/stored_position_provider.hpp>
 #include <vanetza/security/certificate_cache.hpp>
+#include <vanetza/security/certificate_modifications.hpp>
 #include <vanetza/security/default_certificate_validator.hpp>
 #include <vanetza/security/naive_certificate_provider.hpp>
 #include <vanetza/security/trust_store.hpp>
@@ -46,27 +47,10 @@ protected:
     DefaultCertificateValidator cert_validator;
 };
 
-void certificate_remove_time_constraints(Certificate& cert)
-{
-    for (auto it = cert.validity_restriction.begin(); it != cert.validity_restriction.end(); ++it) {
-        const ValidityRestriction& restriction = *it;
-        ValidityRestrictionType type = get_type(restriction);
-        switch (type) {
-            case ValidityRestrictionType::Time_End:
-            case ValidityRestrictionType::Time_Start_And_End:
-            case ValidityRestrictionType::Time_Start_And_Duration:
-                it = cert.validity_restriction.erase(it);
-                break;
-            default:
-                break;
-        }
-    }
-}
-
 TEST_F(DefaultCertificateValidatorTest, validity_time_no_constraint)
 {
     Certificate cert = cert_provider.generate_authorization_ticket();
-    certificate_remove_time_constraints(cert);
+    certificate_remove_restriction(cert, ValidityRestrictionType::Time_Start_And_End);
     cert_provider.sign_authorization_ticket(cert);
 
     CertificateValidity validity = cert_validator.check_certificate(cert);
@@ -77,7 +61,7 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_no_constraint)
 TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_end)
 {
     Certificate cert = cert_provider.generate_authorization_ticket();
-    certificate_remove_time_constraints(cert);
+    certificate_remove_restriction(cert, ValidityRestrictionType::Time_Start_And_End);
 
     StartAndEndValidity restriction;
     restriction.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
@@ -96,7 +80,7 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_end)
 TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_duration)
 {
     Certificate cert = cert_provider.generate_authorization_ticket();
-    certificate_remove_time_constraints(cert);
+    certificate_remove_restriction(cert, ValidityRestrictionType::Time_Start_And_End);
 
     StartAndDurationValidity restriction;
     restriction.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
@@ -115,7 +99,7 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_duration)
 TEST_F(DefaultCertificateValidatorTest, validity_time_end)
 {
     Certificate cert = cert_provider.generate_authorization_ticket();
-    certificate_remove_time_constraints(cert);
+    certificate_remove_restriction(cert, ValidityRestrictionType::Time_Start_And_End);
 
     EndValidity restriction = convert_time32(runtime.now() + std::chrono::hours(23));
     cert.validity_restriction.push_back(restriction);
@@ -136,7 +120,7 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_end)
 TEST_F(DefaultCertificateValidatorTest, validity_time_two_constraints)
 {
     Certificate cert = cert_provider.generate_authorization_ticket();
-    certificate_remove_time_constraints(cert);
+    certificate_remove_restriction(cert, ValidityRestrictionType::Time_Start_And_End);
     // add first constraint
     StartAndEndValidity start_and_end_validity;
     start_and_end_validity.start_validity = convert_time32(runtime.now() - std::chrono::hours(1));
@@ -162,7 +146,7 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_with_parent)
 {
     // The generated authorization ticket's start time is prior to the AA certificate's start time
     Certificate cert = cert_provider.generate_authorization_ticket();
-    certificate_remove_time_constraints(cert);
+    certificate_remove_restriction(cert, ValidityRestrictionType::Time_Start_And_End);
 
     StartAndEndValidity restriction;
     restriction.start_validity = convert_time32(runtime.now() - std::chrono::hours(3));
@@ -183,7 +167,7 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_start_and_end)
 {
     // The generated authorization ticket's start time is prior to the AA certificate's start time
     Certificate cert = cert_provider.generate_authorization_ticket();
-    certificate_remove_time_constraints(cert);
+    certificate_remove_restriction(cert, ValidityRestrictionType::Time_Start_And_End);
 
     StartAndEndValidity restriction;
     restriction.start_validity = convert_time32(runtime.now() + std::chrono::hours(3));

--- a/vanetza/security/tests/default_certificate_validator.cpp
+++ b/vanetza/security/tests/default_certificate_validator.cpp
@@ -128,7 +128,7 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_end)
     // Time period broken, because AA and root CA have start time
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_FALSE(validity);
-    EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, validity.reason());
+    EXPECT_EQ(CertificateInvalidReason::INCONSISTENT_WITH_SIGNER, validity.reason());
 
     // TODO: Add test for certificate, AA and root CA with EndValidity
 }
@@ -176,7 +176,7 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_with_parent)
 
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_FALSE(validity);
-    EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, validity.reason());
+    EXPECT_EQ(CertificateInvalidReason::INCONSISTENT_WITH_SIGNER, validity.reason());
 }
 
 TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_start_and_end)

--- a/vanetza/security/tests/default_certificate_validator.cpp
+++ b/vanetza/security/tests/default_certificate_validator.cpp
@@ -24,6 +24,7 @@ public:
         cert_validator(*backend, runtime.now(), position_provider, trust_store, cert_cache)
     {
         trust_store.insert(cert_provider.root_certificate());
+        cert_cache.insert(cert_provider.aa_certificate());
     }
 
     void set_position(units::GeoAngle latitude, units::GeoAngle longitude)
@@ -70,9 +71,6 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_end)
 
     cert_provider.sign_authorization_ticket(cert);
 
-    cert_cache.insert(cert_provider.aa_certificate());
-    cert_cache.insert(cert_provider.root_certificate());
-
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_TRUE(validity);
 }
@@ -89,9 +87,6 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_start_and_duration)
 
     cert_provider.sign_authorization_ticket(cert);
 
-    cert_cache.insert(cert_provider.aa_certificate());
-    cert_cache.insert(cert_provider.root_certificate());
-
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_TRUE(validity);
 }
@@ -105,9 +100,6 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_end)
     cert.validity_restriction.push_back(restriction);
 
     cert_provider.sign_authorization_ticket(cert);
-
-    cert_cache.insert(cert_provider.aa_certificate());
-    cert_cache.insert(cert_provider.root_certificate());
 
     // Time period broken, because AA and root CA have start time
     CertificateValidity validity = cert_validator.check_certificate(cert);
@@ -134,9 +126,6 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_two_constraints)
     // re-sign certificate
     cert_provider.sign_authorization_ticket(cert);
 
-    cert_cache.insert(cert_provider.aa_certificate());
-    cert_cache.insert(cert_provider.root_certificate());
-
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_FALSE(validity);
     EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, validity.reason());
@@ -154,9 +143,6 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_with_parent)
     cert.validity_restriction.push_back(restriction);
 
     cert_provider.sign_authorization_ticket(cert);
-
-    cert_cache.insert(cert_provider.aa_certificate());
-    cert_cache.insert(cert_provider.root_certificate());
 
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_FALSE(validity);
@@ -176,9 +162,6 @@ TEST_F(DefaultCertificateValidatorTest, validity_time_consistency_start_and_end)
 
     cert_provider.sign_authorization_ticket(cert);
 
-    cert_cache.insert(cert_provider.aa_certificate());
-    cert_cache.insert(cert_provider.root_certificate());
-
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_FALSE(validity);
     EXPECT_EQ(CertificateInvalidReason::BROKEN_TIME_PERIOD, validity.reason());
@@ -192,9 +175,6 @@ TEST_F(DefaultCertificateValidatorTest, validity_region_without_position)
     cert.validity_restriction.push_back(region);
     cert_provider.sign_authorization_ticket(cert);
 
-    cert_cache.insert(cert_provider.aa_certificate());
-    cert_cache.insert(cert_provider.root_certificate());
-
     CertificateValidity validity = cert_validator.check_certificate(cert);
     ASSERT_FALSE(validity);
     EXPECT_EQ(CertificateInvalidReason::OFF_REGION, validity.reason());
@@ -207,9 +187,6 @@ TEST_F(DefaultCertificateValidatorTest, validity_region_circle)
     CircularRegion region { center, 10 * units::si::meter };
     cert.validity_restriction.push_back(region);
     cert_provider.sign_authorization_ticket(cert);
-
-    cert_cache.insert(cert_provider.aa_certificate());
-    cert_cache.insert(cert_provider.root_certificate());
 
     CertificateValidity validity;
     TwoDLocation ego_pos;
@@ -235,9 +212,6 @@ TEST_F(DefaultCertificateValidatorTest, validity_region_rectangle)
     regions.push_back(region);
     cert.validity_restriction.push_back(regions);
     cert_provider.sign_authorization_ticket(cert);
-
-    cert_cache.insert(cert_provider.aa_certificate());
-    cert_cache.insert(cert_provider.root_certificate());
 
     CertificateValidity validity;
     TwoDLocation ego_pos;

--- a/vanetza/security/verify_service.cpp
+++ b/vanetza/security/verify_service.cpp
@@ -49,6 +49,27 @@ bool check_generation_time(Clock::time_point now, const SecuredMessageV2& messag
     return valid;
 }
 
+bool assign_permissions(const Certificate& certificate, VerifyConfirm& confirm)
+{
+    for (auto& subject_attribute : certificate.subject_attributes) {
+        if (get_type(subject_attribute) != SubjectAttributeType::Its_Aid_Ssp_List) {
+            continue;
+        }
+
+        auto permissions = boost::get<std::list<ItsAidSsp> >(subject_attribute);
+        for (auto& permission : permissions) {
+            if (permission.its_aid == confirm.its_aid) {
+                confirm.permissions = permission.service_specific_permissions;
+                return true;
+            }
+        }
+
+        break;
+    }
+
+    return false;
+}
+
 } // namespace
 
 VerifyService straight_verify_service(Runtime& rt, CertificateProvider& cert_provider, CertificateValidator& certs, Backend& backend, CertificateCache& cert_cache, SignHeaderPolicy& sign_policy)
@@ -83,7 +104,12 @@ VerifyService straight_verify_service(Runtime& rt, CertificateProvider& cert_pro
         }
 
         const IntX* its_aid = secured_message.header_field<HeaderFieldType::Its_Aid>();
-        confirm.its_aid = its_aid ? *its_aid : IntX(0);
+        if (!its_aid) {
+            // ITS-AID is required to be present, report as incompatible protocol, as that's the closest match
+            confirm.report = VerificationReport::Incompatible_Protocol;
+            return confirm;
+        }
+        confirm.its_aid = its_aid->get();
 
         const SignerInfo* signer_info = secured_message.header_field<HeaderFieldType::Signer_Info>();
         std::list<Certificate> possible_certificates;
@@ -210,11 +236,11 @@ VerifyService straight_verify_service(Runtime& rt, CertificateProvider& cert_pro
         }
 
         CertificateValidity cert_validity = certs.check_certificate(signer.get());
+        confirm.certificate_validity = cert_validity;
 
         // if certificate could not be verified return correct DecapReport
         if (!cert_validity) {
             confirm.report = VerificationReport::Invalid_Certificate;
-            confirm.certificate_validity = cert_validity;
 
             if (cert_validity.reason() == CertificateInvalidReason::UNKNOWN_SIGNER) {
                 const Certificate& invalid_cert = signer.get();
@@ -222,16 +248,23 @@ VerifyService straight_verify_service(Runtime& rt, CertificateProvider& cert_pro
                     HashedId8 signer_hash = boost::get<HashedId8>(invalid_cert.signer_info);
 
                     confirm.certificate_id = signer_hash;
-                    sign_policy.report_unknown_certificate(*confirm.certificate_id);
+                    sign_policy.report_unknown_certificate(confirm.certificate_id.get());
                 }
             }
 
             return confirm;
         }
 
-        // TODO check if Revoked_Certificate
-
         cert_cache.insert(signer.get());
+
+        // Assign permissions from the certificate based on the message AID already present in the confirm
+        // and reject the certificate if no permissions are present for the claimed AID.
+        if (!assign_permissions(signer.get(), confirm)) {
+            // This might seem weird, because the certificate itself is valid, but not for the received message.
+            confirm.report = VerificationReport::Invalid_Certificate;
+            return confirm;
+        }
+
         confirm.report = VerificationReport::Success;
         return confirm;
     };
@@ -244,7 +277,7 @@ VerifyService dummy_verify_service(VerificationReport report, CertificateValidit
         confirm.report = report;
         confirm.certificate_validity = validity;
         const IntX* its_aid = request.secured_message.header_field<HeaderFieldType::Its_Aid>();
-        confirm.its_aid = its_aid ? *its_aid : IntX(0);
+        confirm.its_aid = its_aid ? its_aid->get() : 0;
         return confirm;
     };
 }

--- a/vanetza/security/verify_service.hpp
+++ b/vanetza/security/verify_service.hpp
@@ -2,6 +2,7 @@
 #define VERIFY_SERVICE_HPP_BR4ISDBH
 
 #include <boost/optional.hpp>
+#include <vanetza/common/its_aid.hpp>
 #include <vanetza/common/byte_buffer.hpp>
 #include <vanetza/security/certificate.hpp>
 #include <vanetza/security/int_x.hpp>
@@ -30,7 +31,7 @@ enum class VerificationReport
     False_Signature,
     Invalid_Certificate,
     Revoked_Certificate,
-    Inconsistant_Chain,
+    Inconsistent_Chain,
     Invalid_Timestamp,
     Duplicate_Message,
     Invalid_Mobility_Data,
@@ -51,7 +52,7 @@ struct VerifyRequest
 struct VerifyConfirm
 {
     VerificationReport report; // mandatory
-    IntX its_aid; // mandatory
+    ItsAid its_aid; // mandatory
     ByteBuffer permissions; // mandatory
     CertificateValidity certificate_validity; // non-standard extension
     boost::optional<HashedId8> certificate_id; // optional


### PR DESCRIPTION
Permissions are now checked and exposed to the upper layers, so the facilities layer can check the SSPs.

I'm not sure about the `Incompatible_Protocol` reason for messages without any application ID, but there doesn't seem to be a good value defined for that.

`Invalid_Certificate` for certificates without proper permissions for the given message seems fine, but it's a bit weird combined with the fact that `certificate_validity` will be `true`.