### PR TITLE
security: Implement is_within for exact matches

### DIFF
--- a/vanetza/security/region.hpp
+++ b/vanetza/security/region.hpp
@@ -31,6 +31,9 @@ struct ThreeDLocation
     geonet::geo_angle_i32t latitude;
     geonet::geo_angle_i32t longitude;
     std::array<uint8_t, 2> elevation;
+
+    bool operator==(const ThreeDLocation&) const;
+    bool operator!=(const ThreeDLocation&) const;
 };
 
 /// TwoDLocation specified in TS 103 097 v1.2.1, section 4.2.18
@@ -46,12 +49,18 @@ struct TwoDLocation
 
     geonet::geo_angle_i32t latitude;
     geonet::geo_angle_i32t longitude;
+
+    bool operator==(const TwoDLocation&) const;
+    bool operator!=(const TwoDLocation&) const;
 };
 
 /// Specified in TS 103 097 v1.2.1, section 4.2.20
 struct NoneRegion
 {
     // empty
+
+    bool operator==(const NoneRegion&) const;
+    bool operator!=(const NoneRegion&) const;
 };
 
 /// CircularRegion specified in TS 103 097 v1.2.1, section 4.2.22
@@ -65,6 +74,9 @@ struct CircularRegion
 
     TwoDLocation center;
     geonet::distance_u16t radius;
+
+    bool operator==(const CircularRegion&) const;
+    bool operator!=(const CircularRegion&) const;
 };
 
 /// RectangularRegion specified in TS 103 097 v1.2.1, section 4.2.23
@@ -72,6 +84,9 @@ struct RectangularRegion
 {
     TwoDLocation northwest;
     TwoDLocation southeast;
+
+    bool operator==(const RectangularRegion&) const;
+    bool operator!=(const RectangularRegion&) const;
 };
 
 /// PolygonalRegion specified in TS 103 097 v1.2.1, section 4.2.24
@@ -90,6 +105,9 @@ struct IdentifiedRegion
     RegionDictionary region_dictionary;
     int16_t region_identifier;
     IntX local_region;
+
+    bool operator==(const IdentifiedRegion&) const;
+    bool operator!=(const IdentifiedRegion&) const;
 };
 
 /// RegionType specified in TS 103 097 v1.2.1, section 4.2.21

--- a/vanetza/security/tests/region.cpp
+++ b/vanetza/security/tests/region.cpp
@@ -203,3 +203,33 @@ TEST(Region, Rectangles_Within_None)
     EXPECT_TRUE(is_within(regions, NoneRegion()));
     EXPECT_FALSE(is_within(NoneRegion(), regions));
 }
+
+TEST(Region, Rectangle_Within_Rectangle_Exact)
+{
+    TwoDLocation northwest_a {
+        static_cast<geo_angle_i32t>(10 * degrees),
+        static_cast<geo_angle_i32t>(10 * degrees)
+    };
+    TwoDLocation southeast_a {
+        static_cast<geo_angle_i32t>(20 * degrees),
+        static_cast<geo_angle_i32t>(20 * degrees)
+    };
+
+    TwoDLocation northwest_b {
+        static_cast<geo_angle_i32t>(10 * degrees),
+        static_cast<geo_angle_i32t>(10 * degrees)
+    };
+    TwoDLocation southeast_b {
+        static_cast<geo_angle_i32t>(20 * degrees),
+        static_cast<geo_angle_i32t>(20 * degrees)
+    };
+
+    RectangularRegion a { northwest_a, southeast_a };
+    RectangularRegion b { northwest_b, southeast_b };
+
+    std::list<RectangularRegion> region_a({ a });
+    std::list<RectangularRegion> region_b({ b });
+
+    EXPECT_TRUE(is_within(region_a, region_b));
+    EXPECT_TRUE(is_within(region_b, region_a));
+}


### PR DESCRIPTION
Exact matches are trivially within themselves. The implementation of this was surprisingly easy, I hope it's right that way.