### PR TITLE
socktap: Disable security if no trusted certificates are given

### DIFF
--- a/tools/socktap/main_bench_in.cpp
+++ b/tools/socktap/main_bench_in.cpp
@@ -122,6 +122,8 @@ int main(int argc, const char** argv)
                 auto trusted_certificate = security::load_certificate_from_file(cert_path);
                 trust_store.insert(trusted_certificate);
             }
+        } else {
+            mib.itsGnSecurity = false;
         }
 
         security::DefaultSignHeaderPolicy sign_header_policy(trigger.runtime().now(), positioning);


### PR DESCRIPTION
This only affects the bench-in variant.