### PR TITLE
WIP: Add multichannel operation with explicit channel selection

### DIFF
--- a/vanetza/common/channel.hpp
+++ b/vanetza/common/channel.hpp
@@ -1,0 +1,34 @@
+#ifndef CHANNEL_HPP
+#define CHANNEL_HPP
+
+#include <cstdint>
+
+namespace vanetza
+{
+
+using Channel = int;
+
+namespace channel
+{
+
+/**
+ * Channel assigned for ETSI ITS
+ * \see TS 102 965 V1.3.1 Annex A
+ */
+constexpr Channel SCH0 = 180;
+constexpr Channel CCH = SCH0;
+
+constexpr Channel SCH1 = 176;
+constexpr Channel SCH2 = 178;
+
+constexpr Channel SCH3 = 174;
+constexpr Channel SCH4 = 172;
+
+constexpr Channel SCH5 = 182;
+constexpr Channel SCH6 = 184;
+
+} // namespace channel
+} // namespace vanetza
+
+#endif /* CHANNEL_HPP */
+

--- a/vanetza/geonet/data_request.hpp
+++ b/vanetza/geonet/data_request.hpp
@@ -1,6 +1,7 @@
 #ifndef DATA_REQUEST_HPP_3JYISVXB
 #define DATA_REQUEST_HPP_3JYISVXB
 
+#include <vanetza/common/channel.hpp>
 #include <vanetza/common/its_aid.hpp>
 #include <vanetza/geonet/address.hpp>
 #include <vanetza/geonet/areas.hpp>
@@ -45,6 +46,7 @@ struct DataRequest
     boost::optional<Repetition> repetition;
     unsigned max_hop_limit;
     TrafficClass traffic_class;
+    Channel channel;
 };
 
 /**

--- a/vanetza/geonet/link_layer.hpp
+++ b/vanetza/geonet/link_layer.hpp
@@ -1,6 +1,7 @@
 #ifndef LINK_LAYER_HPP_F2JBRUTL
 #define LINK_LAYER_HPP_F2JBRUTL
 
+#include <vanetza/common/channel.hpp>
 #include <vanetza/net/mac_address.hpp>
 
 namespace vanetza
@@ -12,6 +13,7 @@ struct LinkLayer
 {
     MacAddress sender;
     MacAddress destination;
+    Channel channel;
 };
 
 } // namespace geonet

--- a/vanetza/geonet/location_table.hpp
+++ b/vanetza/geonet/location_table.hpp
@@ -2,6 +2,7 @@
 #define LOCATION_TABLE_HPP_EMPVZSHQ
 
 #include <vanetza/common/object_container.hpp>
+#include <vanetza/common/channel.hpp>
 #include <vanetza/geonet/address.hpp>
 #include <vanetza/geonet/mib.hpp>
 #include <vanetza/geonet/position_vector.hpp>
@@ -15,20 +16,58 @@ namespace vanetza
 namespace geonet
 {
 
+class LinkInfoEntry
+{
+public:
+    LinkInfoEntry(const Runtime& rt);
+
+    const MacAddress& link_layer_address() const { return m_link_layer_address; }
+    void set_link_layer_address(const MacAddress& mac) { m_link_layer_address = mac; }
+
+    const Channel channel() const { return m_channel; }
+    void set_channel(const Channel channel) { m_channel = channel; }
+
+    double get_pdr() const { return m_pdr; }
+    void update_pdr(std::size_t packet_size, double beta = 0.5);
+
+private:
+    MacAddress m_link_layer_address;
+    Channel m_channel;
+
+    double m_pdr; /*< packet data rate in bytes per second */
+    Clock::time_point m_pdr_update;
+
+    const Runtime& m_runtime;
+};
+
+class LinkInfoEntryCreator
+{
+public:
+    LinkInfoEntryCreator(const Runtime& rt) : m_runtime(rt) {}
+    LinkInfoEntry operator()() { return LinkInfoEntry(m_runtime); }
+
+private:
+    const Runtime& m_runtime;
+};
+
 class LocationTableEntry
 {
 public:
+    using link_info_table_type = SoftStateMap<Channel, LinkInfoEntry, LinkInfoEntryCreator>;
+
     LocationTableEntry(const Runtime& rt);
 
     const Address& geonet_address() const;
-    const MacAddress& link_layer_address() const;
+    const MacAddress& link_layer_address(Channel channel) const;
+    bool has_channel(Channel channel) const;
     StationType station_type() const;
 
     /**
      * Get packed data rate (PDR) of corresponding source.
+     * \param channel desired channel
      * \return PDR in bytes per second, might be not-a-number
      */
-    double get_pdr() const { return m_pdr; }
+    double get_pdr(Channel channel) const;
 
     /**
      * Update packet data rate.
@@ -36,7 +75,7 @@ public:
      * \param packet_size received number of bytes
      * \param beta weight factor for exponential moving average ]0; 1[
      */
-    void update_pdr(std::size_t packet_size, double beta = 0.5);
+    void update_pdr(Channel channel, std::size_t packet_size, double beta = 0.5);
 
     /**
      * Check if position vector has been set before
@@ -57,6 +96,8 @@ public:
      * \return true if position vector passed time stamp check
      */
     bool update_position_vector(const LongPositionVector& pv);
+
+    void add_link(const Channel channel, const MacAddress& address);
 
     /**
      * Check if this entry belongs to a direct neighbour
@@ -83,8 +124,8 @@ private:
     bool m_is_neighbour;
     bool m_has_position_vector;
     LongPositionVector m_position_vector;
-    double m_pdr; /*< packet data rate in bytes per second */
-    Clock::time_point m_pdr_update;
+
+    link_info_table_type m_link_info;
 };
 
 class LocationTableEntryCreator
@@ -97,6 +138,16 @@ private:
     const Runtime& m_runtime;
 };
 
+class LinkTableEntry
+{
+public:
+    const Address& geonet_address() const { return m_geonet_address; }
+    void set_geonet_address(const Address& addr) { m_geonet_address = addr; }
+
+private:
+    Address m_geonet_address;
+};
+
 /**
  * GeoNetworking LocationTable
  * See section 7.1 of EN 302 636-4-1 for details.
@@ -104,9 +155,9 @@ private:
 class LocationTable
 {
 public:
-    using table_type = SoftStateMap<MacAddress, LocationTableEntry, LocationTableEntryCreator>;
-    using entry_visitor = std::function<void(const MacAddress&, const LocationTableEntry&)>;
-    using entry_predicate = std::function<bool(const MacAddress&, const LocationTableEntry&)>;
+    using table_type = SoftStateMap<Address, LocationTableEntry, LocationTableEntryCreator>;
+    using entry_visitor = std::function<void(const Address&, const LocationTableEntry&)>;
+    using entry_predicate = std::function<bool(const Address&, const LocationTableEntry&)>;
     using entry_range =
         boost::select_second_const_range<
             boost::filtered_range<
@@ -114,8 +165,11 @@ public:
                 const typename table_type::map_range>>;
     using neighbour_range = entry_range;
 
+    using link_table_type = SoftStateMap<MacAddress, LinkTableEntry>;
+
     LocationTable(const MIB&, Runtime&);
     bool has_entry(const Address&) const;
+    void update(const Channel, const MacAddress&, const Address&);
     LocationTableEntry& update(const LongPositionVector&);
     LocationTableEntry& get_or_create_entry(const Address&);
     LocationTableEntry& get_or_create_entry(const MacAddress&);
@@ -124,13 +178,16 @@ public:
     const LongPositionVector* get_position(const Address&) const;
     const LongPositionVector* get_position(const MacAddress&) const;
     bool has_neighbours() const;
+    bool has_neighbours(Channel) const;
     neighbour_range neighbours() const;
+    neighbour_range neighbours(Channel) const;
     entry_range filter(const entry_predicate&) const;
     void visit(const entry_visitor&) const;
-    void drop_expired() { m_table.drop_expired(); }
+    void drop_expired();
 
 private:
     table_type m_table;
+    link_table_type m_link_table;
 };
 
 } // namespace geonet


### PR DESCRIPTION
This adds multichannel operation with explicit channel selection.

This adds a LinkTable integrated into LocationTable for tracking link layer addresses associated with a GeoNetworking address.
LocationTableEntry has been extended with a LinkInfoTable to support tracking information pertinent to a link, such as packet data rate.

Missing:
- [ ] tests
- [ ] channel offloading support.
- [ ] callbacks upon GeoNetworking/link layer address change due to address collision