### PR TITLE
Support for altitude/elevation and altitude confidence

### DIFF
--- a/tools/socktap/gps_position_provider.cpp
+++ b/tools/socktap/gps_position_provider.cpp
@@ -1,6 +1,8 @@
 #include "gps_position_provider.hpp"
 #include <vanetza/units/angle.hpp>
+#include <vanetza/common/confident_quantity.hpp>
 #include <vanetza/units/velocity.hpp>
+#include <vanetza/units/length.hpp>
 #include <cmath>
 
 static_assert(GPSD_API_MAJOR_VERSION >= 5 || GPSD_API_MAJOR_VERSION <= 7, "libgps has incompatible API");
@@ -91,6 +93,11 @@ void GpsPositionProvider::fetch_position_fix()
             }
         } else {
             fetched_position_fix.confidence = vanetza::PositionConfidence();
+        }
+        if (gps_data.fix.mode == MODE_3D) {
+            fetched_position_fix.altitude = vanetza::ConfidentQuantity<vanetza::units::Length>(gps_data.fix.altitude * si::meter, gps_data.fix.epv * si::meter);
+        } else {
+            fetched_position_fix.altitude = boost::none;
         }
     }
 }

--- a/vanetza/common/position_fix.hpp
+++ b/vanetza/common/position_fix.hpp
@@ -1,11 +1,13 @@
 #ifndef POSITION_FIX_HPP_BGU14Q9D
 #define POSITION_FIX_HPP_BGU14Q9D
 
+#include <boost/optional.hpp>
 #include <vanetza/common/clock.hpp>
 #include <vanetza/common/confident_quantity.hpp>
 #include <vanetza/common/position_confidence.hpp>
 #include <vanetza/units/angle.hpp>
 #include <vanetza/units/velocity.hpp>
+#include <vanetza/units/length.hpp>
 
 namespace vanetza
 {
@@ -18,6 +20,7 @@ struct PositionFix
     PositionConfidence confidence;
     ConfidentQuantity<units::TrueNorth> course;
     ConfidentQuantity<units::Velocity> speed;
+    boost::optional<ConfidentQuantity<units::Length>> altitude;
 };
 
 } // namespace vanetza

--- a/vanetza/facilities/cam_functions.cpp
+++ b/vanetza/facilities/cam_functions.cpp
@@ -143,6 +143,41 @@ bool is_available(const ReferencePosition& pos)
     return pos.latitude != Latitude_unavailable && pos.longitude != Longitude_unavailable;
 }
 
+AltitudeConfidence_t to_altitude_confidence(const double& alt_con) {
+	if (alt_con < 0 || std::isnan(alt_con)) {
+		return AltitudeConfidence_unavailable;
+	} else if (alt_con <= 0.01) {
+		return AltitudeConfidence_alt_000_01;
+	} else if (alt_con <= 0.02) {
+		return AltitudeConfidence_alt_000_02;
+	} else if (alt_con <= 0.05) {
+		return AltitudeConfidence_alt_000_05;
+	} else if (alt_con <= 0.1) {
+		return AltitudeConfidence_alt_000_10;
+	} else if (alt_con <= 0.2) {
+		return AltitudeConfidence_alt_000_20;
+	} else if (alt_con <= 0.5) {
+		return AltitudeConfidence_alt_000_50;
+	} else if (alt_con <= 1.0) {
+		return AltitudeConfidence_alt_001_00;
+	} else if (alt_con <= 2.0) {
+		return AltitudeConfidence_alt_002_00;
+	} else if (alt_con <= 5.0) {
+		return AltitudeConfidence_alt_005_00;
+	} else if (alt_con <= 10.0) {
+		return AltitudeConfidence_alt_010_00;
+	} else if (alt_con <= 20.0) {
+		return AltitudeConfidence_alt_020_00;
+	} else if (alt_con <= 50.0) {
+		return AltitudeConfidence_alt_050_00;
+	} else if (alt_con <= 100.0) {
+		return AltitudeConfidence_alt_100_00;
+	} else if (alt_con <= 200.0) {
+		return AltitudeConfidence_alt_200_00;
+	}
+	return AltitudeConfidence_outOfRange;
+}
+
 bool check_service_specific_permissions(const asn1::Cam& cam, security::CamPermissions ssp)
 {
     using security::CamPermission;

--- a/vanetza/facilities/cam_functions.hpp
+++ b/vanetza/facilities/cam_functions.hpp
@@ -1,8 +1,13 @@
 #ifndef CAM_FUNCTIONS_HPP_PUFKBEM8
 #define CAM_FUNCTIONS_HPP_PUFKBEM8
 
+#include <boost/units/make_scaled_unit.hpp>
+#include <boost/units/quantity.hpp>
+#include <boost/units/systems/si.hpp>
+#include <vanetza/asn1/its/AltitudeConfidence.h>
 #include <vanetza/asn1/its/Heading.h>
 #include <vanetza/asn1/its/ReferencePosition.h>
+#include <vanetza/geonet/units.hpp>
 #include <vanetza/security/cam_ssp.hpp>
 #include <vanetza/units/angle.hpp>
 #include <vanetza/units/length.hpp>
@@ -18,6 +23,13 @@ namespace asn1 { class Cam; }
 
 namespace facilities
 {
+using geonet::geo_angle_i32t;
+
+// altitude in centimeters
+typedef boost::units::quantity<boost::units::make_scaled_unit<
+        boost::units::si::length,
+        boost::units::scale<10, boost::units::static_rational<-2>>
+    >::type, int32_t> altitude_i32t;
 
 class PathHistory;
 
@@ -54,6 +66,8 @@ units::Length distance(const ReferencePosition_t& a, units::GeoAngle lat, units:
  */
 bool is_available(const Heading&);
 bool is_available(const ReferencePosition_t&);
+
+AltitudeConfidence_t to_altitude_confidence(const double&);
 
 /**
  * Check if a CAM contains only allowed data elements

--- a/vanetza/security/region.hpp
+++ b/vanetza/security/region.hpp
@@ -5,6 +5,7 @@
 #include <vanetza/security/int_x.hpp>
 #include <vanetza/units/angle.hpp>
 #include <vanetza/units/length.hpp>
+#include <boost/optional/optional.hpp>
 #include <boost/variant/variant.hpp>
 #include <list>
 
@@ -391,6 +392,13 @@ bool is_within(const GeographicRegion&, const PolygonalRegion&);
  * \true if pos is within region
  */
 bool is_within(const GeographicRegion&, const IdentifiedRegion&);
+
+/**
+ * \brief Convert PositionFix' altitude to elevation representation from TS 103 097 v1.2.1, section 4.2.19
+ * \param altitude altitude value as obtained from PositionFix
+ * \return encoded elevation value
+ */
+std::array<uint8_t, 2> to_elevation(const double&);
 
 } //namespace security
 } //namespace vanetza

--- a/vanetza/security/sign_header_policy.cpp
+++ b/vanetza/security/sign_header_policy.cpp
@@ -47,9 +47,12 @@ std::list<HeaderField> DefaultSignHeaderPolicy::prepare_header(const SignRequest
         m_cert_requested = false;
         m_chain_requested = false;
     } else {
-        // TODO: Add elevation once available via PositionFix
         auto position = m_positioning.position_fix();
-        header_fields.push_back(ThreeDLocation(position.latitude, position.longitude));
+        if (position.altitude) {
+            header_fields.push_back(ThreeDLocation(position.latitude, position.longitude, to_elevation(position.altitude->value().value())));
+        } else {
+            header_fields.push_back(ThreeDLocation(position.latitude, position.longitude));
+        }
         header_fields.push_back(SignerInfo { certificate_provider.own_certificate() });
     }
 

--- a/vanetza/security/tests/region.cpp
+++ b/vanetza/security/tests/region.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <gtest/gtest.h>
 #include <vanetza/security/region.hpp>
 #include <vanetza/security/tests/check_region.hpp>
@@ -232,4 +233,22 @@ TEST(Region, Rectangle_Within_Rectangle_Exact)
 
     EXPECT_TRUE(is_within(region_a, region_b));
     EXPECT_TRUE(is_within(region_b, region_a));
+}
+
+TEST(Region, Altitude_To_Elevation)
+{
+	double altitude_empty = NAN;
+	std::array<uint8_t, 2> elevation(ThreeDLocation::unknown_elevation);
+
+	EXPECT_EQ(to_elevation(altitude_empty), elevation);
+
+	double altitude_positive = 2843.6;
+	std::array<uint8_t, 2> elevation_positive = { 0x6F, 0x14 };
+
+	EXPECT_EQ(to_elevation(altitude_positive), elevation_positive);
+
+	double altitude_negative = -170.2;
+	std::array<uint8_t, 2> elevation_negative = { 0xF9, 0x5A };
+
+	EXPECT_EQ(to_elevation(altitude_negative), elevation_negative);
 }


### PR DESCRIPTION
- Adds an attribute for altitude and altitude confidence to PositionFix
- Translates altitude from PositionFix into elevation in SecurityHeader's location (see [ETSI TS 103 097 v.1.2.1, section 4.2.19](https://www.etsi.org/deliver/etsi_ts/103000_103099/103097/01.02.01_60/ts_103097v010201p.pdf))
- Adds support for altitude and altitude confidence to socktap (read GPS fix in position provider and use during CAM generation)