### PR TITLE
Miscellaneous small improvements for socktap and certify

### DIFF
--- a/tools/certify/commands/generate-ticket.cpp
+++ b/tools/certify/commands/generate-ticket.cpp
@@ -31,6 +31,7 @@ bool GenerateTicketCommand::parse(const std::vector<std::string>& opts)
         ("days", po::value<int>(&validity_days)->default_value(7), "Validity in days.")
         ("cam-permissions", po::value<std::string>(&cam_permissions), "CAM permissions as binary string (e.g. '1111111111111100' to grant all SSPs)")
         ("denm-permissions", po::value<std::string>(&denm_permissions), "DENM permissions as binary string (e.g. '000000000000000000000000' to grant no SSPs)")
+        ("include-gn-mgmt", "Include GN-MGMT's SSP (empty)")
     ;
 
     po::positional_options_description pos;
@@ -52,6 +53,8 @@ bool GenerateTicketCommand::parse(const std::vector<std::string>& opts)
 
         return false;
     }
+
+    include_gn_mgmt = vm.count("include-gn-mgmt") > 0;
 
     return true;
 }
@@ -111,6 +114,10 @@ int GenerateTicketCommand::execute()
     certificate_ssp_den.its_aid = IntX(aid::DEN);
     certificate_ssp_den.service_specific_permissions = denm_ssps;
     certificate_ssp.push_back(certificate_ssp_den);
+
+    if (include_gn_mgmt) {
+        certificate_ssp.push_back({IntX(aid::GN_MGMT), vanetza::ByteBuffer{}});
+    }
 
     certificate.signer_info = calculate_hash(sign_cert);
     certificate.subject_info.subject_type = SubjectType::Authorization_Ticket;

--- a/tools/certify/commands/generate-ticket.cpp
+++ b/tools/certify/commands/generate-ticket.cpp
@@ -31,7 +31,7 @@ bool GenerateTicketCommand::parse(const std::vector<std::string>& opts)
         ("days", po::value<int>(&validity_days)->default_value(7), "Validity in days.")
         ("cam-permissions", po::value<std::string>(&cam_permissions), "CAM permissions as binary string (e.g. '1111111111111100' to grant all SSPs)")
         ("denm-permissions", po::value<std::string>(&denm_permissions), "DENM permissions as binary string (e.g. '000000000000000000000000' to grant no SSPs)")
-        ("include-gn-mgmt", "Include GN-MGMT's SSP (empty)")
+        ("permit-gn-mgmt", "Generated ticket can be used to sign GN-MGMT messages (e.g. beacons).")
     ;
 
     po::positional_options_description pos;
@@ -54,7 +54,7 @@ bool GenerateTicketCommand::parse(const std::vector<std::string>& opts)
         return false;
     }
 
-    include_gn_mgmt = vm.count("include-gn-mgmt") > 0;
+    permit_gn_mgmt = vm.count("permit-gn-mgmt") > 0;
 
     return true;
 }
@@ -115,7 +115,7 @@ int GenerateTicketCommand::execute()
     certificate_ssp_den.service_specific_permissions = denm_ssps;
     certificate_ssp.push_back(certificate_ssp_den);
 
-    if (include_gn_mgmt) {
+    if (permit_gn_mgmt) {
         certificate_ssp.push_back({IntX(aid::GN_MGMT), vanetza::ByteBuffer{}});
     }
 

--- a/tools/certify/commands/generate-ticket.hpp
+++ b/tools/certify/commands/generate-ticket.hpp
@@ -17,6 +17,7 @@ private:
     int validity_days;
     std::string cam_permissions;
     std::string denm_permissions;
+    bool include_gn_mgmt;
 };
 
 #endif /* CERTIFY_COMMANDS_GENERATE_TICKET_HPP */

--- a/tools/certify/commands/generate-ticket.hpp
+++ b/tools/certify/commands/generate-ticket.hpp
@@ -17,7 +17,7 @@ private:
     int validity_days;
     std::string cam_permissions;
     std::string denm_permissions;
-    bool include_gn_mgmt;
+    bool permit_gn_mgmt;
 };
 
 #endif /* CERTIFY_COMMANDS_GENERATE_TICKET_HPP */

--- a/tools/socktap/cam_application.cpp
+++ b/tools/socktap/cam_application.cpp
@@ -21,7 +21,7 @@ CamApplication::CamApplication(PositionProvider& positioning, const Runtime& rt,
 
 CamApplication::PortType CamApplication::port()
 {
-    return host_cast<uint16_t>(2001);
+    return btp::ports::CAM;
 }
 
 void CamApplication::indicate(const DataIndication& indication, UpPacketPtr packet)

--- a/tools/socktap/cam_application.cpp
+++ b/tools/socktap/cam_application.cpp
@@ -1,7 +1,6 @@
 #include "cam_application.hpp"
 #include <vanetza/btp/ports.hpp>
 #include <vanetza/asn1/cam.hpp>
-#include <boost/units/cmath.hpp>
 #include <boost/units/systems/si/prefixes.hpp>
 #include <chrono>
 #include <exception>
@@ -11,16 +10,8 @@
 // This is rather simple application that sends CAMs in a regular interval.
 
 using namespace vanetza;
+using namespace vanetza::geonet;
 using namespace std::chrono;
-
-auto microdegree = vanetza::units::degree * boost::units::si::micro;
-
-template<typename T, typename U>
-long round(const boost::units::quantity<T>& q, const U& u)
-{
-	boost::units::quantity<U> v { q };
-	return std::round(v.value());
-}
 
 CamApplication::CamApplication(PositionProvider& positioning, const Runtime& rt, boost::asio::steady_timer& timer, milliseconds cam_interval)
     : positioning_(positioning), runtime_(rt), cam_interval_(cam_interval), timer_(timer)
@@ -76,8 +67,8 @@ void CamApplication::on_timer(const boost::system::error_code& ec)
     BasicContainer_t& basic = cam.camParameters.basicContainer;
     basic.stationType = StationType_passengerCar;
     basic.referencePosition.altitude.altitudeValue = AltitudeValue_unavailable;
-    basic.referencePosition.longitude = round(position.longitude, microdegree) * Longitude_oneMicrodegreeEast;
-    basic.referencePosition.latitude = round(position.latitude, microdegree) * Latitude_oneMicrodegreeNorth;
+    basic.referencePosition.longitude = std::round(static_cast<geo_angle_i32t>(position.longitude).value());
+    basic.referencePosition.latitude = std::round(static_cast<geo_angle_i32t>(position.latitude).value());
     basic.referencePosition.positionConfidenceEllipse.semiMajorOrientation = HeadingValue_unavailable;
     basic.referencePosition.positionConfidenceEllipse.semiMajorConfidence = SemiAxisLength_unavailable;
     basic.referencePosition.positionConfidenceEllipse.semiMinorConfidence = SemiAxisLength_unavailable;

--- a/tools/socktap/gps_position_provider.cpp
+++ b/tools/socktap/gps_position_provider.cpp
@@ -76,9 +76,6 @@ void GpsPositionProvider::fetch_position_fix()
         fetched_position_fix.longitude = gps_data.fix.longitude * degree;
         fetched_position_fix.speed.assign(gps_data.fix.speed * si::meter_per_second, gps_data.fix.eps * si::meter_per_second);
         fetched_position_fix.course.assign(north + gps_data.fix.track * degree, north + gps_data.fix.epd * degree);
-        fetched_position_fix.timestamp = convert(gps_data.fix.time);
-        fetched_position_fix.latitude = gps_data.fix.latitude * degree;
-        fetched_position_fix.longitude = gps_data.fix.longitude * degree;
         if (!std::isnan(gps_data.fix.epx) && !std::isnan(gps_data.fix.epy)) {
             if (gps_data.fix.epx > gps_data.fix.epy) {
                 fetched_position_fix.confidence.semi_minor = gps_data.fix.epy * si::meter;


### PR DESCRIPTION
### Certify

Because the GeoNet router automatically sends GN beacons under certain conditions (and if beaconing is not disabled) and because these beacons belong to AID 141 GN-MGMT, an ITS station that wants to sign a beacon needs to have AID 141 and its (empty) SSP vector in its authorization ticket. Hence, this PR adds a command-line option to certify's `generate-ticket` to include the AID/SSP for GN-MGMT.

### Socktap-Common

- Remove duplicate assignment of some attributes.

### Socktap-Cam

- Use the BTP port enum value instead of a magic number.
- Reuse the boost unit cast from geonet to convert lat and lon to the correct representation for CAM generation.