### PR TITLE
socktap: update to Cohda LLC network interface

### DIFF
--- a/cmake/FindCohda.cmake
+++ b/cmake/FindCohda.cmake
@@ -1,5 +1,5 @@
 find_path(COHDA_ROOT
-    NAMES "ieee1609/app/lib1609/include/lib1609.h"
+    NAMES "ieee1609/app/lib1609/include/lib1609.h" "cohda/kernel/include/linux/cohda/llc/llc-api.h"
     PATHS "/home/duser"
     PATH_SUFFIXES mk5 mk2
     CMAKE_FIND_ROOT_PATH_BOTH
@@ -7,12 +7,12 @@ find_path(COHDA_ROOT
 
 set(COHDA_KERNEL_INCLUDE_DIR ${COHDA_ROOT}/ieee1609/kernel/include)
 set(COHDA_LIB1609_INCLUDE_DIR ${COHDA_ROOT}/ieee1609/app/lib1609/include)
-set(COHDA_INCLUDE_DIRS ${COHDA_KERNEL_INCLUDE_DIR} ${COHDA_LIB1609_INCLUDE_DIR})
+set(COHDA_LLC_INCLUDE_DIR ${COHDA_ROOT}/cohda/kernel/include/linux/cohda/llc)
+set(COHDA_INCLUDE_DIRS ${COHDA_KERNEL_INCLUDE_DIR} ${COHDA_LIB1609_INCLUDE_DIR} ${COHDA_LLC_INCLUDE_DIR})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Cohda "Cohda SDK not found" COHDA_ROOT)
 mark_as_advanced(COHDA_ROOT)
-
 if(COHDA_FOUND AND NOT TARGET Cohda::headers)
     add_library(Cohda::headers UNKNOWN IMPORTED)
     set_target_properties(Cohda::headers PROPERTIES

--- a/doc/cohda-sdk-build.md
+++ b/doc/cohda-sdk-build.md
@@ -8,24 +8,8 @@ At the end, we have Vanetza libraries and its *socktap* tool cross-compiled for 
 
 [Cohda SDK](http://www.cohdawireless.com/solutions/sdk/) is provided by [Cohda Wireless](http://www.cohdawireless.com) along with their [MK5](http://www.cohdawireless.com/solutions/hardware/mk5-obu/) units.
 Since you are reading this build how-to you most likely already possess one of these units.
-This how-to has been created for the Release 14.1 of the SDK.
+This how-to has been created for the Release 16 of the SDK.
 The following instructions are expected to be done within the virtual machine (VM) provided by Cohda.
-
-
-## CMake upgrade
-
-Unfortunately, the CMake version 2.8.12 included in the Cohda VM is too old for building Vanetza.
-You can overcome this situation easily by downloading a more recent version, e.g. [CMake 3.1.3](https://cmake.org/files/v3.1/cmake-3.1.3-Linux-i386.tar.gz) or newer is known to work well.
-Just make sure to download an i386 build of CMake because the VM runs a 32-bit Linux.
-After downloading CMake, extract it in your home directory and add the CMake binary path to your PATH variable:
-
-    cd /home/duser
-    tar xzf cmake-3.1.3-Linux-i386.tar.gz
-    echo 'export PATH=$HOME/cmake-3.1.3-Linux-i386/bin:$PATH' >> .bashrc
-
-Verify that the newly installed CMake is now used by default:
-    cmake --version
-This should output `cmake version 3.1.3` if CMake is working correctly.
 
 
 ## Vanetza build dependencies
@@ -53,7 +37,7 @@ Create a build directory and tell CMake to use the cross-compiler installed in t
         -DCMAKE_INSTALL_PREFIX=$HOME/vanetza-dist
     make
 
-This builds the Vanetza libraries only. Enable the **BUILD_SOCKTAP** CMake option if you want to try *socktap* as well.
+This builds the Vanetza libraries only. Enable the **BUILD_SOCKTAP** CMake option if you want to try *socktap* as well. Additionally, enable the **SOCKTAP_WITH_COHDA_LLC** CMake option if you want *socktap* to use 802.11p via Cohda's LLC network interface on your MK5.
 Fortunately, *socktap*'s additional *gpsd* dependency is already shipped with the Cohda SDK itself.
 You only need to specify its location by setting **GPS_LIBRARY** to `/home/duser/mk5/stack/v2x-lib/lib/mk5/libgps.a` and **GPS_INCLUDE_DIR** to `/home/duser/mk5/stack/v2x-lib/include`.
 Please note, that *socktap* does not make use of Cohda's socket API currently.
@@ -73,4 +57,4 @@ Copy the shared object files (*.so) from `$HOME/vanetza-deps/libs` onto the MK5,
 3. copy *socktap* onto MK5
 
 Copy the files from `$HOME/vanetza-dist` to `/home/duser/vanetza` on the MK5, i.e. Vanetza libraries and its dependency libraries are located in the same directory.
-You can execute *socktap* located at `/home/duser/vanetza/bin/socktap` and it will look up its shared objects in the sibling `lib` directory.
+You can execute *socktap* located at `/home/duser/vanetza/bin/socktap` and it will look up its shared objects in the sibling `lib` directory. If you have enabled the **SOCKTAP_WITH_COHDA_LLC** CMake option, make sure to give *socktap* the name of a Cohda LLC network interface via the command line option `--interface`/`-i` (e.g. cw-llc0).

--- a/tools/cohda_proxy/CMakeLists.txt
+++ b/tools/cohda_proxy/CMakeLists.txt
@@ -1,4 +1,4 @@
 find_package(Cohda MODULE REQUIRED)
 add_executable(cohda_proxy proxy.cpp proxy_handler.cpp)
 target_include_directories(cohda_proxy PUBLIC ${COHDA_INCLUDE_DIRS})
-target_link_libraries(cohda_proxy Boost::system net)
+target_link_libraries(cohda_proxy Boost::system access net)

--- a/tools/cohda_proxy/proxy_handler.cpp
+++ b/tools/cohda_proxy/proxy_handler.cpp
@@ -109,13 +109,13 @@ void ProxyHandler::send_ota(const vanetza::ProxyHeader& header, std::size_t leng
             m_mk2_tx.Priority = MK2_PRIO_1;
             break;
         case vanetza::access::AccessCategory::BE:
-            m_mk2_tx.Priority = MK2_PRIO_0;
+            m_mk2_tx.Priority = MK2_PRIO_3;
             break;
         case vanetza::access::AccessCategory::VI:
             m_mk2_tx.Priority = MK2_PRIO_5;
             break;
         case vanetza::access::AccessCategory::VO:
-            m_mk2_tx.Priority = MK2_PRIO_6;
+            m_mk2_tx.Priority = MK2_PRIO_7;
             break;
         default:
             assert(false && "Unknown access category");

--- a/tools/cohda_proxy/proxy_handler.cpp
+++ b/tools/cohda_proxy/proxy_handler.cpp
@@ -105,16 +105,16 @@ void ProxyHandler::send_ota(const vanetza::ProxyHeader& header, std::size_t leng
     m_mk2_tx.TxPower.ManualPower = std::round(power * 2);
     // I suppose MK2 priorities are derived from 802.1d
     switch (get_access_category(header)) {
-        case vanetza::AccessCategory::BK:
+        case vanetza::access::AccessCategory::BK:
             m_mk2_tx.Priority = MK2_PRIO_1;
             break;
-        case vanetza::AccessCategory::BE:
+        case vanetza::access::AccessCategory::BE:
             m_mk2_tx.Priority = MK2_PRIO_0;
             break;
-        case vanetza::AccessCategory::VI:
+        case vanetza::access::AccessCategory::VI:
             m_mk2_tx.Priority = MK2_PRIO_5;
             break;
-        case vanetza::AccessCategory::VO:
+        case vanetza::access::AccessCategory::VO:
             m_mk2_tx.Priority = MK2_PRIO_6;
             break;
         default:

--- a/tools/socktap/CMakeLists.txt
+++ b/tools/socktap/CMakeLists.txt
@@ -44,8 +44,8 @@ install(TARGETS socktap-hello EXPORT ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL
 install(TARGETS socktap-cam EXPORT ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(TARGETS socktap-bench-in EXPORT ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-if(TARGET Cohda::headers)
-    target_compile_definitions(socktap-common PUBLIC "SOCKTAP_WITH_COHDA_SDK")
+if(TARGET Cohda::headers AND SOCKTAP_WITH_COHDA_LLC)
+    target_compile_definitions(socktap-common PUBLIC "SOCKTAP_WITH_COHDA_LLC")
     target_include_directories(socktap-common PRIVATE "${COHDA_INCLUDE_DIRS}")
     target_sources(socktap-common PRIVATE cohda.cpp)
 endif()

--- a/tools/socktap/cohda.cpp
+++ b/tools/socktap/cohda.cpp
@@ -1,41 +1,149 @@
 #include "cohda.hpp"
-#include <vanetza/dcc/data_request.hpp>
-#include <cassert>
-#include <mk2mac-api-types.h>
+#include <boost/crc.hpp>
+#include <iostream>
+#include <llc-api.h>
+#include <vanetza/geonet/router.hpp>
+#include <vanetza/geonet/address.hpp>
+#include <vanetza/dcc/profile.hpp>
+#include <vanetza/common/byte_order.hpp>
 
-namespace vanetza
-{
+namespace vanetza {
 
-using dcc::Profile;
+struct LLCHeader {
+    uint8_t DSAP = 0xAA;
+    uint8_t SSAP = 0xAA;
+    uint8_t ControlField = 0x03;
+    uint8_t OUI[3] = { 0x00, 0x00, 0x00 };
+    uint16_t ProtocolID = geonet::ether_type.net();
+};
 
-ByteBuffer create_cohda_tx_header(const dcc::DataRequest& request)
-{
-    ByteBuffer header(sizeof(tMK2TxDescriptor), 0x00);
-    assert(header.size() == sizeof(tMK2TxDescriptor));
-    tMK2TxDescriptor* tx = reinterpret_cast<tMK2TxDescriptor*>(header.data());
-    tx->ChannelNumber = 180;
+/* See ETSI EN 302 663 V1.2.1 (2013-07), Table B.3 */
+enum tPriority {
+    AC_BK = 1, AC_BE = 3, AC_VI = 5, AC_VO = 6
+};
+constexpr uint8_t QOS_PRIO_MASK = 0x07;
+
+/**
+ * 1 bit payload type (MSDU = 0)
+ * 2 bits ack policy (No_Ack = 1)
+ * 1 bit EOSP (service period = 0)
+ * 1 bit unused
+ * 3 bits prioriy (set dynamically according to traffic class)
+ * 8 bits TXOP (shall be set to 0 when communicating outside of a BSS)
+ */
+struct tQOSControl {
+    uint8_t QOSFlags = 0x20;
+    uint8_t TXOP = 0; // not used
+};
+
+struct tIEEE80211PHeader {
+    uint8_t FrameControlVersionAndType = 0x88;
+    uint8_t FrameControlFlags = 0x00; // not used
+    uint16_t DurationID = 0x00; // not used
+    uint8_t Destination[6];
+    uint8_t Source[6];
+    uint8_t BSSID[6] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }; // Operation outside of a BSS, (see ETSI EN 302 663 V1.2.1 Annex A)
+    uint16_t SequenceControl = 0x00; // 12 bits for sequence number, 4 bits for fragment number; will be set by Cohda LLC
+    tQOSControl QOSControl;
+};
+
+struct tTXPhysical {
+    tMKxTxPacket TxMessage;
+    tIEEE80211PHeader IEEE80211PHeader;
+};
+
+constexpr uint8_t IEEE80211P_FCS_LENGTH = 4;
+constexpr uint32_t CRC32_MAGIC_NUMBER = 0x2144df1c;
+
+struct tRXPhysical {
+    tMKxRxPacket RxMessage;
+    tIEEE80211PHeader IEEE80211PHeader;
+};
+
+void insert_cohda_tx_header(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket>& packet) {
+    LLCHeader llcData;
+    auto llcPtr = reinterpret_cast<uint8_t*>(&llcData);
+    packet->layer(OsiLayer::Link) = std::move(ByteBuffer(llcPtr, llcPtr + sizeof(LLCHeader)));
+
+    tTXPhysical phyData;
+    phyData.TxMessage = {};
+    std::copy(request.destination.octets.begin(), request.destination.octets.end(), phyData.IEEE80211PHeader.Destination);
+    std::copy(request.source.octets.begin(), request.source.octets.end(), phyData.IEEE80211PHeader.Source);
     switch (request.dcc_profile) {
-        case Profile::DP0:
-            tx->Priority = 7; // AC_VO
+        case dcc::Profile::DP0:
+            phyData.IEEE80211PHeader.QOSControl.QOSFlags |= QOS_PRIO_MASK & tPriority::AC_VO; // AC_VO (Voice)
             break;
-        case Profile::DP1:
-            tx->Priority = 5; // AC_VI
+        case dcc::Profile::DP1:
+            phyData.IEEE80211PHeader.QOSControl.QOSFlags |= QOS_PRIO_MASK & tPriority::AC_VI; // AC_VI (Video)
             break;
-        case Profile::DP2:
-            tx->Priority = 3; // AC_BE
+        case dcc::Profile::DP2:
+            phyData.IEEE80211PHeader.QOSControl.QOSFlags |= QOS_PRIO_MASK & tPriority::AC_BE; // AC_BE (Best effort)
             break;
-        case Profile::DP3:
-            tx->Priority = 1; // AC_BK
+        case dcc::Profile::DP3:
+            phyData.IEEE80211PHeader.QOSControl.QOSFlags |= QOS_PRIO_MASK & tPriority::AC_BK; // AC_BK (Background)
             break;
         default:
-            tx->Priority = MK2_PRIO_NON_QOS;
+            phyData.IEEE80211PHeader.QOSControl.QOSFlags |= QOS_PRIO_MASK & tPriority::AC_BE;
             break;
     }
-    tx->Service = MK2_QOS_ACK;
-    tx->MCS = MK2MCS_DEFAULT;
-    tx->TxPower.PowerSetting = MK2TPC_DEFAULT;
-    tx->TxAntenna = MK2_TXANT_DEFAULT;
-    return header;
+
+    uint16_t payload_size = sizeof(tIEEE80211PHeader) + packet->size(OsiLayer::Link, OsiLayer::Application);
+    uint16_t total_size = sizeof(tMKxTxPacket) + payload_size;
+
+    phyData.TxMessage.Hdr.Type = MKXIF_TXPACKET;
+    phyData.TxMessage.Hdr.Len = total_size;
+
+    phyData.TxMessage.TxPacketData.TxAntenna = MKX_ANT_DEFAULT;
+    phyData.TxMessage.TxPacketData.TxFrameLength = payload_size;
+
+    auto phyPtr = reinterpret_cast<uint8_t*>(&phyData);
+    packet->layer(OsiLayer::Physical) = std::move(ByteBuffer(phyPtr, phyPtr + sizeof(tTXPhysical)));
+}
+
+boost::optional<EthernetHeader> strip_cohda_rx_header(CohesivePacket& packet) {
+    if (packet.size(OsiLayer::Physical) < sizeof(tRXPhysical) + IEEE80211P_FCS_LENGTH) {
+        return boost::none;
+    }
+    packet.set_boundary(OsiLayer::Physical, sizeof(tRXPhysical));
+
+    tRXPhysical* rxPhy = reinterpret_cast<tRXPhysical*>(&*packet[OsiLayer::Physical].begin());
+    if (rxPhy->RxMessage.Hdr.Type != MKXIF_RXPACKET) {
+        return boost::none;
+    }
+    if (packet.size() != rxPhy->RxMessage.Hdr.Len) {
+        return boost::none;
+    }
+    if (packet.size() - sizeof(tMKxRxPacket) != rxPhy->RxMessage.RxPacketData.RxFrameLength) {
+        return boost::none;
+    }
+
+    boost::crc_32_type crc_result;
+    /*
+     * Process the whole 802.11p frame (including its FCS). If the FCS is correct, the CRC result has the same value
+     * as the CRC of one block (32 bit) of zeroes.
+     */
+    crc_result.process_bytes(packet.buffer().data() + sizeof(tMKxRxPacket), packet.size() - sizeof(tMKxRxPacket));
+    if (crc_result.checksum() != CRC32_MAGIC_NUMBER) {
+        return boost::none;
+    }
+    packet.trim(OsiLayer::Link, packet.size() - IEEE80211P_FCS_LENGTH);
+
+    if (packet.size(OsiLayer::Link) < sizeof(LLCHeader)) {
+        return boost::none;
+    }
+    packet.set_boundary(OsiLayer::Link, sizeof(LLCHeader));
+
+    LLCHeader *llcData = reinterpret_cast<LLCHeader*>(&*packet[OsiLayer::Link].begin());
+
+    EthernetHeader eth;
+    std::memcpy(eth.destination.octets.begin(), rxPhy->IEEE80211PHeader.Destination, MacAddress::length_bytes);
+    std::memcpy(eth.source.octets.begin(), rxPhy->IEEE80211PHeader.Source, MacAddress::length_bytes);
+    eth.type = host_cast<uint16_t>(ntoh(llcData->ProtocolID));
+
+    if (eth.type != geonet::ether_type) {
+        return boost::none;
+    }
+    return eth;
 }
 
 } // namespace vanetza

--- a/tools/socktap/cohda.cpp
+++ b/tools/socktap/cohda.cpp
@@ -1,88 +1,34 @@
 #include "cohda.hpp"
-#include <iostream>
-#include <cstring>
 #include <llc-api.h>
-#include <vanetza/geonet/router.hpp>
-#include <vanetza/geonet/address.hpp>
+#include <vanetza/access/g5_link_layer.hpp>
 #include <vanetza/dcc/profile.hpp>
-#include <vanetza/common/byte_order.hpp>
 
 namespace vanetza {
-/* See ETSI EN 302 663 V1.2.1 (2013-07), Table B.3 */
-enum Priority {
-    AC_BK = 1, AC_BE = 3, AC_VI = 5, AC_VO = 6
-};
-
-/**
- * QoS Control subfields in these bits have predetermined values during transmission and the same expected values
- * during reception either because of 802.11p and the frame type (QoS data frame) used or because of the set of
- * supported features (Ack Policy: only No Ack is supported, A-MSDU present: no A-MSDU supported).
- */
-constexpr uint8_t QOS_FIXED_FIELDS_MASK = 0xE8;
-constexpr uint8_t QOS_USER_PRIORITY_MASK = 0x07;
-
-struct QOSControl {
-    /**
-     * 1 bit A-MSDU present (not an A-MSDU = 0)
-     * 2 bits Ack Policy (No Ack = 1)
-     * 1 bit EOSP (not used)
-     * 1 bit MSB of TID, must be 0
-     * 3 bits other three bits of TID, used for user priority (according to traffic class)
-     */
-    uint8_t qos_flags = 0x20;
-    uint8_t txop = 0; // Not used
-};
-
-struct IEEE802Dot11PHeader {
-    uint8_t frame_control_protocol_version_and_type = 0x88; // Only protocol version 0 and QoS data frames supported
-    uint8_t frame_control_flags = 0x00; // Not used
-    uint16_t duration_or_id = 0; // Not used
-    uint8_t destination[6];
-    uint8_t source[6];
-    uint8_t bssid[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }; // Operation outside of a BSS, must be set to wildcard (all bits 1)
-    uint16_t sequence_control = 0x0000; // 12 bits for sequence number, 4 bits for fragment number; will be set by Cohda LLC during transmission
-    QOSControl qos_control;
-};
-
-struct LLCHeader {
-    uint8_t dsap = 0xAA;
-    uint8_t ssap = 0xAA;
-    uint8_t control_field = 0x03;
-    uint8_t oui[3] = { 0x00, 0x00, 0x00 };
-    uint16_t protocol_id = geonet::ether_type.net();
-};
-
-struct LinkLayer {
-    IEEE802Dot11PHeader ieee802dot11p_header;
-    LLCHeader llc_header;
-};
-
-constexpr uint8_t IEEE802DOT11P_FCS_LENGTH = 4;
 
 void insert_cohda_tx_header(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket>& packet) {
-    LinkLayer link_layer;
-    IEEE802Dot11PHeader& mac_header = link_layer.ieee802dot11p_header;
+    access::G5LinkLayer link_layer;
+    access::IEEE802Dot11PHeader& mac_header = link_layer.ieee802dot11p_header;
     std::copy(request.destination.octets.begin(), request.destination.octets.end(), mac_header.destination);
     std::copy(request.source.octets.begin(), request.source.octets.end(), mac_header.source);
     switch (request.dcc_profile) {
         case dcc::Profile::DP0:
-            mac_header.qos_control.qos_flags |= QOS_USER_PRIORITY_MASK & Priority::AC_VO; // AC_VO (Voice)
+            mac_header.qos_control.priority(access::Priority::AC_VO); // AC_VO (Voice)
             break;
         case dcc::Profile::DP1:
-            mac_header.qos_control.qos_flags |= QOS_USER_PRIORITY_MASK & Priority::AC_VI; // AC_VI (Video)
+            mac_header.qos_control.priority(access::Priority::AC_VI); // AC_VI (Video)
             break;
         case dcc::Profile::DP2:
-            mac_header.qos_control.qos_flags |= QOS_USER_PRIORITY_MASK & Priority::AC_BE; // AC_BE (Best effort)
+            mac_header.qos_control.priority(access::Priority::AC_BE); // AC_BE (Best effort)
             break;
         case dcc::Profile::DP3:
-            mac_header.qos_control.qos_flags |= QOS_USER_PRIORITY_MASK & Priority::AC_BK; // AC_BK (Background)
+            mac_header.qos_control.priority(access::Priority::AC_BK); // AC_BK (Background)
             break;
         default:
-            mac_header.qos_control.qos_flags |= QOS_USER_PRIORITY_MASK & Priority::AC_BE;
+            mac_header.qos_control.priority(access::Priority::AC_BE);
             break;
     }
     auto link_layer_ptr = reinterpret_cast<uint8_t*>(&link_layer);
-    packet->layer(OsiLayer::Link) = std::move(ByteBuffer(link_layer_ptr, link_layer_ptr + sizeof(LinkLayer)));
+    packet->layer(OsiLayer::Link) = std::move(ByteBuffer(link_layer_ptr, link_layer_ptr + sizeof(access::G5LinkLayer)));
 
     uint16_t payload_size = packet->size();
     uint16_t total_size = sizeof(tMKxTxPacket) + payload_size;
@@ -97,7 +43,7 @@ void insert_cohda_tx_header(const dcc::DataRequest& request, std::unique_ptr<Chu
 }
 
 boost::optional<EthernetHeader> strip_cohda_rx_header(CohesivePacket& packet) {
-    if (packet.size(OsiLayer::Physical) < sizeof(tMKxRxPacket) + sizeof(LinkLayer) + IEEE802DOT11P_FCS_LENGTH) {
+    if (packet.size(OsiLayer::Physical) < sizeof(tMKxRxPacket) + sizeof(access::G5LinkLayer) + access::ieee802dot11p_fcs_length) {
         return boost::none;
     }
     packet.set_boundary(OsiLayer::Physical, sizeof(tMKxRxPacket));
@@ -113,29 +59,18 @@ boost::optional<EthernetHeader> strip_cohda_rx_header(CohesivePacket& packet) {
     if (!phy->RxPacketData.FCSPass) {
         return boost::none;
     }
-    packet.trim(OsiLayer::Link, packet.size() - IEEE802DOT11P_FCS_LENGTH);
-    packet.set_boundary(OsiLayer::Link, sizeof(LinkLayer));
+    packet.trim(OsiLayer::Link, packet.size() - access::ieee802dot11p_fcs_length);
+    packet.set_boundary(OsiLayer::Link, sizeof(access::G5LinkLayer));
 
-    LinkLayer* link_layer_ptr = reinterpret_cast<LinkLayer*>(&*packet[OsiLayer::Link].begin());
-    IEEE802Dot11PHeader& mac_header = link_layer_ptr->ieee802dot11p_header;
-    LLCHeader& llc_header = link_layer_ptr->llc_header;
-    // For most explicitly initialized link layer header fields, their (default) value is expected in received frames
-    LinkLayer expected_link_layer;
-    IEEE802Dot11PHeader& expected_mac_header = expected_link_layer.ieee802dot11p_header;
-    LLCHeader& expected_llc_header = expected_link_layer.llc_header;
-
-    if (mac_header.frame_control_protocol_version_and_type != expected_mac_header.frame_control_protocol_version_and_type
-            || mac_header.frame_control_flags != expected_mac_header.frame_control_flags
-            || std::memcmp(mac_header.bssid, expected_mac_header.bssid, sizeof(mac_header.bssid))
-            || (mac_header.qos_control.qos_flags & QOS_FIXED_FIELDS_MASK) != (expected_mac_header.qos_control.qos_flags & QOS_FIXED_FIELDS_MASK)
-            || std::memcmp(&llc_header, &expected_llc_header, sizeof(llc_header))) {
+    access::G5LinkLayer* link_layer_ptr = reinterpret_cast<access::G5LinkLayer*>(&*packet[OsiLayer::Link].begin());
+    if (!access::check_fixed_fields(*link_layer_ptr)) {
         return boost::none;
     }
 
     EthernetHeader eth;
     std::memcpy(eth.destination.octets.begin(), link_layer_ptr->ieee802dot11p_header.destination, MacAddress::length_bytes);
     std::memcpy(eth.source.octets.begin(), link_layer_ptr->ieee802dot11p_header.source, MacAddress::length_bytes);
-    eth.type = host_cast<uint16_t>(ntoh(link_layer_ptr->llc_header.protocol_id));
+    eth.type = host_cast<uint16_t>(ntoh(link_layer_ptr->llc_snap_header.protocol_id));
 
     return eth;
 }

--- a/tools/socktap/cohda.cpp
+++ b/tools/socktap/cohda.cpp
@@ -1,5 +1,4 @@
 #include "cohda.hpp"
-#include <boost/crc.hpp>
 #include <iostream>
 #include <llc-api.h>
 #include <vanetza/geonet/router.hpp>

--- a/tools/socktap/cohda.cpp
+++ b/tools/socktap/cohda.cpp
@@ -52,7 +52,6 @@ struct LinkLayer {
 };
 
 constexpr uint8_t IEEE802DOT11P_FCS_LENGTH = 4;
-constexpr uint32_t CRC32_MAGIC_NUMBER = 0x2144df1c;
 
 void insert_cohda_tx_header(const dcc::DataRequest& request, std::unique_ptr<ChunkPacket>& packet) {
     LinkLayer link_layer;
@@ -107,13 +106,7 @@ boost::optional<EthernetHeader> strip_cohda_rx_header(CohesivePacket& packet) {
         return boost::none;
     }
 
-    boost::crc_32_type crc_result;
-    /*
-     * Process the whole 802.11p frame (including its FCS). If the FCS is correct, the CRC result has the same value
-     * as the CRC of one block (4 byte) of zeroes.
-     */
-    crc_result.process_bytes(packet.buffer().data() + sizeof(tMKxRxPacket), packet.size() - sizeof(tMKxRxPacket));
-    if (crc_result.checksum() != CRC32_MAGIC_NUMBER) {
+    if (!phy->RxPacketData.FCSPass) {
         return boost::none;
     }
     packet.trim(OsiLayer::Link, packet.size() - IEEE802DOT11P_FCS_LENGTH);

--- a/tools/socktap/cohda.hpp
+++ b/tools/socktap/cohda.hpp
@@ -1,8 +1,13 @@
 #ifndef COHDA_HPP_GBENHCVN
 #define COHDA_HPP_GBENHCVN
 
+#include <boost/optional/optional.hpp>
 #include <vanetza/common/byte_buffer.hpp>
+#include <vanetza/net/chunk_packet.hpp>
 #include <vanetza/common/clock.hpp>
+#include <vanetza/dcc/data_request.hpp>
+#include <vanetza/net/ethernet_header.hpp>
+#include <vanetza/net/cohesive_packet.hpp>
 
 namespace vanetza
 {
@@ -10,7 +15,9 @@ namespace vanetza
 // forward declaration
 namespace dcc { class DataRequest; }
 
-ByteBuffer create_cohda_tx_header(const dcc::DataRequest&);
+void insert_cohda_tx_header(const dcc::DataRequest&, std::unique_ptr<ChunkPacket>&);
+
+boost::optional<EthernetHeader> strip_cohda_rx_header(CohesivePacket&);
 
 } // namespace vanetza
 

--- a/tools/socktap/ethernet_device.cpp
+++ b/tools/socktap/ethernet_device.cpp
@@ -2,6 +2,9 @@
 #include <algorithm>
 #include <cstring>
 #include <system_error>
+#ifdef SOCKTAP_WITH_COHDA_LLC
+#include <linux/if_ether.h>
+#endif
 #include <linux/if_packet.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
@@ -32,6 +35,9 @@ EthernetDevice::protocol::endpoint EthernetDevice::endpoint(int family) const
 {
     sockaddr_ll socket_address = {0};
     socket_address.sll_family = family;
+#ifdef SOCKTAP_WITH_COHDA_LLC
+    socket_address.sll_protocol = htons(ETH_P_ALL);
+#endif
     socket_address.sll_ifindex = index();
     return protocol::endpoint(&socket_address, sizeof(sockaddr_ll));
 }

--- a/vanetza/access/CMakeLists.txt
+++ b/vanetza/access/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CXX_SOURCES
+    access_category.cpp
     data_rates.cpp
 )
 add_vanetza_component(access ${CXX_SOURCES})

--- a/vanetza/access/access_category.cpp
+++ b/vanetza/access/access_category.cpp
@@ -1,7 +1,9 @@
-#include "access_category.hpp"
+#include <vanetza/access/access_category.hpp>
 #include <iostream>
 
 namespace vanetza
+{
+namespace access
 {
 
 std::ostream& operator<<(std::ostream& os, AccessCategory ac)
@@ -26,5 +28,6 @@ std::ostream& operator<<(std::ostream& os, AccessCategory ac)
     return os;
 }
 
+} // namespace access
 } // namespace vanetza
 

--- a/vanetza/access/access_category.hpp
+++ b/vanetza/access/access_category.hpp
@@ -8,11 +8,12 @@ namespace vanetza
 namespace access
 {
 
+/* See ETSI EN 302 663 V1.2.1 (2013-07), Table B.3 */
 enum class AccessCategory {
-    BK = 0,
-    BE = 1,
-    VI = 2,
-    VO = 3
+    BK = 1,
+    BE = 3,
+    VI = 5,
+    VO = 7
 };
 
 std::ostream& operator<<(std::ostream&, AccessCategory);

--- a/vanetza/access/access_category.hpp
+++ b/vanetza/access/access_category.hpp
@@ -5,6 +5,8 @@
 
 namespace vanetza
 {
+namespace access
+{
 
 enum class AccessCategory {
     BK = 0,
@@ -15,7 +17,7 @@ enum class AccessCategory {
 
 std::ostream& operator<<(std::ostream&, AccessCategory);
 
+} // namespace access
 } // namespace vanetza
 
 #endif /* ACCESS_CATEGORY_HPP_QAWSOPED */
-

--- a/vanetza/access/data_request.hpp
+++ b/vanetza/access/data_request.hpp
@@ -1,8 +1,8 @@
 #ifndef DATA_REQUEST_HPP_3OGGPFWF
 #define DATA_REQUEST_HPP_3OGGPFWF
 
+#include <vanetza/access/access_category.hpp>
 #include <vanetza/common/byte_order.hpp>
-#include <vanetza/net/access_category.hpp>
 #include <vanetza/net/mac_address.hpp>
 
 namespace vanetza

--- a/vanetza/access/g5_link_layer.hpp
+++ b/vanetza/access/g5_link_layer.hpp
@@ -38,7 +38,7 @@ struct IEEE802Dot11PHeader {
     uint8_t destination[6];
     uint8_t source[6];
     uint8_t bssid[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }; // Operation outside of a BSS, must be set to wildcard (all bits 1)
-    uint16_t sequence_control = 0x0000; // 12 bits for sequence number, 4 bits for fragment number; will be set by Cohda LLC during transmission
+    uint16_t sequence_control = 0x0000; // 12 bits for sequence number, 4 bits for fragment number
     QOSControl qos_control;
 };
 

--- a/vanetza/access/g5_link_layer.hpp
+++ b/vanetza/access/g5_link_layer.hpp
@@ -2,6 +2,7 @@
 #define G5_LINK_LAYER
 #include <cstdint>
 #include <cstring>
+#include <vanetza/access/access_category.hpp>
 #include <vanetza/geonet/router.hpp>
 
 namespace vanetza {
@@ -16,11 +17,6 @@ constexpr uint8_t qos_fixed_fields_mask = 0xE8;
 constexpr uint8_t qos_user_priority_mask = 0x07;
 } // namespace
 
-/* See ETSI EN 302 663 V1.2.1 (2013-07), Table B.3 */
-enum Priority {
-    AC_BK = 1, AC_BE = 3, AC_VI = 5, AC_VO = 6
-};
-
 struct QOSControl {
     /**
      * 1 bit A-MSDU present (not an A-MSDU = 0)
@@ -32,7 +28,7 @@ struct QOSControl {
     uint8_t qos_flags = 0x20;
     uint8_t txop = 0; // Not used
 
-    void priority(Priority prio) { qos_flags |= static_cast<int>(prio) & qos_user_priority_mask; }
+    void user_priority(AccessCategory access_category) { qos_flags |= static_cast<int>(access_category) & qos_user_priority_mask; }
 };
 
 struct IEEE802Dot11PHeader {

--- a/vanetza/access/g5_link_layer.hpp
+++ b/vanetza/access/g5_link_layer.hpp
@@ -1,0 +1,87 @@
+#ifndef G5_LINK_LAYER
+#define G5_LINK_LAYER
+#include <cstdint>
+#include <cstring>
+#include <vanetza/geonet/router.hpp>
+
+namespace vanetza {
+namespace access {
+namespace { // anonymous namespace for local constants
+/**
+ * QoS Control subfields in these bits have predetermined values during transmission and the same expected values
+ * during reception either because of 802.11p and the frame type (QoS data frame) used or because of the set of
+ * supported features (Ack Policy: only No Ack is supported, A-MSDU present: no A-MSDU supported).
+ */
+constexpr uint8_t qos_fixed_fields_mask = 0xE8;
+constexpr uint8_t qos_user_priority_mask = 0x07;
+} // namespace
+
+/* See ETSI EN 302 663 V1.2.1 (2013-07), Table B.3 */
+enum Priority {
+    AC_BK = 1, AC_BE = 3, AC_VI = 5, AC_VO = 6
+};
+
+struct QOSControl {
+    /**
+     * 1 bit A-MSDU present (not an A-MSDU = 0)
+     * 2 bits Ack Policy (No Ack = 1)
+     * 1 bit EOSP (not used)
+     * 1 bit MSB of TID, must be 0
+     * 3 bits other three bits of TID, used for user priority (according to traffic class)
+     */
+    uint8_t qos_flags = 0x20;
+    uint8_t txop = 0; // Not used
+
+    void priority(Priority prio) { qos_flags |= static_cast<int>(prio) & qos_user_priority_mask; }
+};
+
+struct IEEE802Dot11PHeader {
+    uint8_t frame_control_protocol_version_and_type = 0x88; // Only protocol version 0 and QoS data frames supported
+    uint8_t frame_control_flags = 0x00; // Not supported
+    uint16_t duration_or_id = 0; // Not used
+    uint8_t destination[6];
+    uint8_t source[6];
+    uint8_t bssid[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }; // Operation outside of a BSS, must be set to wildcard (all bits 1)
+    uint16_t sequence_control = 0x0000; // 12 bits for sequence number, 4 bits for fragment number; will be set by Cohda LLC during transmission
+    QOSControl qos_control;
+};
+
+constexpr uint8_t ieee802dot11p_fcs_length = 4;
+
+struct LLCSNAPHeader {
+    uint8_t dsap = 0xAA;
+    uint8_t ssap = 0xAA;
+    uint8_t control_field = 0x03;
+    uint8_t oui[3] = { 0x00, 0x00, 0x00 };
+    uint16_t protocol_id = geonet::ether_type.net();
+};
+
+struct G5LinkLayer {
+    IEEE802Dot11PHeader ieee802dot11p_header;
+    LLCSNAPHeader llc_snap_header;
+};
+
+/**
+ * \brief Check whether some link layer header fields contain their expected values.
+ * For most explicitly initialized link layer header fields, their (default) value is expected in received frames.
+ *
+ * \param link_layer G5LinkLayer to check
+ * \return whether all expected values are present
+ */
+bool check_fixed_fields(const G5LinkLayer& link_layer) {
+    const IEEE802Dot11PHeader& mac_header = link_layer.ieee802dot11p_header;
+    const LLCSNAPHeader& llc_header = link_layer.llc_snap_header;
+    G5LinkLayer default_link_layer;
+    IEEE802Dot11PHeader& default_mac_header = default_link_layer.ieee802dot11p_header;
+    LLCSNAPHeader& default_llc_header = default_link_layer.llc_snap_header;
+    return mac_header.frame_control_protocol_version_and_type == default_mac_header.frame_control_protocol_version_and_type
+                && mac_header.frame_control_flags == default_mac_header.frame_control_flags
+                && !std::memcmp(mac_header.bssid, default_mac_header.bssid, sizeof(mac_header.bssid))
+                && (mac_header.qos_control.qos_flags & qos_fixed_fields_mask) == (default_mac_header.qos_control.qos_flags & qos_fixed_fields_mask)
+                && !std::memcmp(&llc_header, &default_llc_header, sizeof(llc_header));
+}
+
+} // namespace access
+} // namespace vanetza
+
+#endif /* G5_LINK_LAYER */

--- a/vanetza/dcc/flow_control.cpp
+++ b/vanetza/dcc/flow_control.cpp
@@ -103,7 +103,7 @@ bool FlowControl::transmit_immediately(const Transmission& transmission) const
 bool FlowControl::empty() const
 {
     return std::all_of(m_queues.cbegin(), m_queues.cend(),
-            [](const std::pair<AccessCategory, const Queue&>& kv) {
+            [](const std::pair<access::AccessCategory, const Queue&>& kv) {
                 return kv.second.empty();
             });
 }
@@ -135,7 +135,7 @@ FlowControl::PendingTransmission* FlowControl::next_transmission()
 void FlowControl::drop_expired()
 {
     for (auto& kv : m_queues) {
-        AccessCategory ac = kv.first;
+        access::AccessCategory ac = kv.first;
         Queue& queue = kv.second;
         queue.remove_if([this, ac](const PendingTransmission& transmission) {
             bool drop = transmission.expiry < m_runtime.now();

--- a/vanetza/dcc/flow_control.hpp
+++ b/vanetza/dcc/flow_control.hpp
@@ -7,9 +7,9 @@
 #include <vanetza/dcc/interface.hpp>
 #include <vanetza/dcc/profile.hpp>
 #include <vanetza/dcc/transmission.hpp>
-#include <vanetza/net/access_category.hpp>
 #include <vanetza/net/chunk_packet.hpp>
 #include <boost/optional/optional.hpp>
+#include <vanetza/access/access_category.hpp>
 #include <list>
 #include <memory>
 #include <map>
@@ -37,8 +37,8 @@ class TransmitRateControl;
 class FlowControl : public RequestInterface
 {
 public:
-    using PacketDropHook = Hook<AccessCategory, const ChunkPacket*>;
-    using PacketTransmitHook = Hook<AccessCategory, const ChunkPacket*>;
+    using PacketDropHook = Hook<access::AccessCategory, const ChunkPacket*>;
+    using PacketTransmitHook = Hook<access::AccessCategory, const ChunkPacket*>;
 
     /**
      * Create FlowControl instance
@@ -113,7 +113,7 @@ private:
     Runtime& m_runtime;
     TransmitRateControl& m_trc;
     access::Interface& m_access;
-    std::map<AccessCategory, Queue, std::greater<AccessCategory>> m_queues;
+    std::map<access::AccessCategory, Queue, std::greater<access::AccessCategory>> m_queues;
     std::size_t m_queue_length;
     PacketDropHook m_packet_drop_hook;
     PacketTransmitHook m_packet_transmit_hook;

--- a/vanetza/dcc/mapping.cpp
+++ b/vanetza/dcc/mapping.cpp
@@ -6,23 +6,23 @@ namespace vanetza
 namespace dcc
 {
 
-AccessCategory map_profile_onto_ac(Profile dp_id)
+access::AccessCategory map_profile_onto_ac(Profile dp_id)
 {
-    AccessCategory ac = AccessCategory::BE;
+    access::AccessCategory ac = access::AccessCategory::BE;
 
     switch (dp_id)
     {
         case Profile::DP0:
-            ac = AccessCategory::VO;
+            ac = access::AccessCategory::VO;
             break;
         case Profile::DP1:
-            ac = AccessCategory::VI;
+            ac = access::AccessCategory::VI;
             break;
         case Profile::DP2:
-            ac = AccessCategory::BE;
+            ac = access::AccessCategory::BE;
             break;
         case Profile::DP3:
-            ac = AccessCategory::BK;
+            ac = access::AccessCategory::BK;
             break;
         default:
             throw std::invalid_argument("Invalid DCC Profile ID");

--- a/vanetza/dcc/mapping.hpp
+++ b/vanetza/dcc/mapping.hpp
@@ -1,8 +1,8 @@
 #ifndef MAPPING_HPP_MZ2RU7VX
 #define MAPPING_HPP_MZ2RU7VX
 
+#include <vanetza/access/access_category.hpp>
 #include <vanetza/dcc/profile.hpp>
-#include <vanetza/net/access_category.hpp>
 
 namespace vanetza
 {
@@ -14,7 +14,7 @@ namespace dcc
  * \param profile DCC Profile ID
  * \return mapped access category
  */
-AccessCategory map_profile_onto_ac(Profile);
+access::AccessCategory map_profile_onto_ac(Profile);
 
 } // namespace dcc
 } // namespace vanetza

--- a/vanetza/dcc/tests/flow_control.cpp
+++ b/vanetza/dcc/tests/flow_control.cpp
@@ -84,7 +84,7 @@ TEST_F(FlowControlTest, immediate_transmission)
     request.dcc_profile = Profile::DP1;
     flow_control.request(request, create_packet());
     ASSERT_TRUE(!!access.last_request);
-    EXPECT_EQ(AccessCategory::VI, access.last_request->access_category);
+    EXPECT_EQ(access::AccessCategory::VI, access.last_request->access_category);
 
     EXPECT_EQ(trc.interval(dp2), trc.delay(dp2));
     request.dcc_profile = Profile::DP2;
@@ -157,8 +157,8 @@ TEST_F(FlowControlTest, queuing)
 
 TEST_F(FlowControlTest, drop_expired)
 {
-    std::list<AccessCategory> drops;
-    flow_control.set_packet_drop_hook([&drops](AccessCategory ac, const ChunkPacket*) {
+    std::list<access::AccessCategory> drops;
+    flow_control.set_packet_drop_hook([&drops](access::AccessCategory ac, const ChunkPacket*) {
             drops.push_back(ac);
     });
 
@@ -170,7 +170,7 @@ TEST_F(FlowControlTest, drop_expired)
     runtime.trigger(trc.delay(dp3) + milliseconds(10));
     EXPECT_FALSE(access.last_request);
     ASSERT_FALSE(drops.empty());
-    EXPECT_EQ(AccessCategory::BK, drops.back());
+    EXPECT_EQ(access::AccessCategory::BK, drops.back());
     EXPECT_EQ(0, access.transmissions);
 
     trc.notify(dp3);
@@ -205,7 +205,7 @@ TEST_F(FlowControlTest, queue_length)
 
     // count drops
     std::size_t drops = 0;
-    flow_control.set_packet_drop_hook([&drops](AccessCategory, const ChunkPacket*) { ++drops; });
+    flow_control.set_packet_drop_hook([&drops](access::AccessCategory, const ChunkPacket*) { ++drops; });
 
     DataRequest request;
     request.dcc_profile = Profile::DP1;

--- a/vanetza/dcc/tests/mapping.cpp
+++ b/vanetza/dcc/tests/mapping.cpp
@@ -6,10 +6,10 @@ using namespace vanetza::dcc;
 
 TEST(Mapping, map_profile_onto_ac)
 {
-    EXPECT_EQ(AccessCategory::VO, map_profile_onto_ac(Profile::DP0));
-    EXPECT_EQ(AccessCategory::VI, map_profile_onto_ac(Profile::DP1));
-    EXPECT_EQ(AccessCategory::BE, map_profile_onto_ac(Profile::DP2));
-    EXPECT_EQ(AccessCategory::BK, map_profile_onto_ac(Profile::DP3));
+    EXPECT_EQ(access::AccessCategory::VO, map_profile_onto_ac(Profile::DP0));
+    EXPECT_EQ(access::AccessCategory::VI, map_profile_onto_ac(Profile::DP1));
+    EXPECT_EQ(access::AccessCategory::BE, map_profile_onto_ac(Profile::DP2));
+    EXPECT_EQ(access::AccessCategory::BK, map_profile_onto_ac(Profile::DP3));
 
     auto malicious_profile = static_cast<Profile>(4);
     EXPECT_THROW(map_profile_onto_ac(malicious_profile), std::invalid_argument);

--- a/vanetza/net/CMakeLists.txt
+++ b/vanetza/net/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(CXX_SOURCES
-    access_category.cpp
     buffer_packet.cpp
     chunk_packet.cpp
     cohesive_packet.cpp

--- a/vanetza/net/proxy_header.cpp
+++ b/vanetza/net/proxy_header.cpp
@@ -18,12 +18,12 @@ void set_signal_power(ProxyHeader& header, double dbm)
     header.signal_power = hton(power);
 }
 
-AccessCategory get_access_category(const ProxyHeader& header)
+access::AccessCategory get_access_category(const ProxyHeader& header)
 {
-    return static_cast<AccessCategory>(header.access_category & 0x03);
+    return static_cast<access::AccessCategory>(header.access_category & 0x07);
 }
 
-void set_access_category(ProxyHeader& header, AccessCategory ac)
+void set_access_category(ProxyHeader& header, access::AccessCategory ac)
 {
     header.access_category = static_cast<uint8_t>(ac);
 }

--- a/vanetza/net/proxy_header.hpp
+++ b/vanetza/net/proxy_header.hpp
@@ -1,8 +1,8 @@
 #ifndef PROXY_HEADER_HPP_JWTV3BDT
 #define PROXY_HEADER_HPP_JWTV3BDT
 
-#include <vanetza/net/access_category.hpp>
 #include <boost/range/iterator_range.hpp>
+#include <vanetza/access/access_category.hpp>
 #include <cstdint>
 
 namespace vanetza
@@ -37,8 +37,8 @@ static_assert(sizeof(ProxyHeader) == 9, "ProxyHeader has invalid size");
 
 double get_signal_power(const ProxyHeader&);
 void set_signal_power(ProxyHeader&, double dbm);
-AccessCategory get_access_category(const ProxyHeader&);
-void set_access_category(ProxyHeader&, AccessCategory);
+access::AccessCategory get_access_category(const ProxyHeader&);
+void set_access_category(ProxyHeader&, access::AccessCategory);
 boost::iterator_range<const uint8_t*> get_payload(const ProxyHeader&, std::size_t);
 void set_payload(ProxyHeader&, std::size_t);
 


### PR DESCRIPTION
Cohda has discontinued the WAVE network interfaces on the MK5 devices some time ago and added 'Cohda LLC' network interfaces. When using raw sockets like before, these interfaces expect Cohda LLC interface messages with 802.11p frames that are almost ready for transmission (sequence number and frame control sequence (CRC32) is inserted/added by the interface).

This PR replaces the old MK2Tx/RxDescriptors in socktap by the corresponding Cohda LLC interface messages and adds generation and parsing of the packet contents below GN, namely the LLC header (**logical link control, not the same as the Cohda LLC interface/API!**) and the 802.11 header.

The Cohda LLC interface/API is available for Cohda Release 15 firmware and later. Furthermore, the old WAVE implementation in socktap might no longer work for Release 15 firmware and later.