### PR TITLE
Add transmit/drop hooks in flow_control reporting destination ports

### DIFF
--- a/vanetza/dcc/CMakeLists.txt
+++ b/vanetza/dcc/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CXX_SOURCES
 )
 
 add_vanetza_component(dcc ${CXX_SOURCES})
-target_link_libraries(dcc PUBLIC access btp net)
+target_link_libraries(dcc PUBLIC access net)
 
 add_test_subdirectory(tests)
 

--- a/vanetza/dcc/CMakeLists.txt
+++ b/vanetza/dcc/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CXX_SOURCES
 )
 
 add_vanetza_component(dcc ${CXX_SOURCES})
-target_link_libraries(dcc PUBLIC access net)
+target_link_libraries(dcc PUBLIC access btp net)
 
 add_test_subdirectory(tests)
 

--- a/vanetza/dcc/flow_control.cpp
+++ b/vanetza/dcc/flow_control.cpp
@@ -164,9 +164,9 @@ void FlowControl::set_packet_drop_hook(PacketDropHook::callback_type&& cb)
     m_packet_drop_hook = std::move(cb);
 }
 
-void FlowControl::set_packet_drop_hook(PacketDropHookPort::callback_type&& cb)
+void FlowControl::set_packet_drop_hook(PacketDropHookGeneric::callback_type&& cb)
 {
-    m_packet_drop_hook_port = std::move(cb);
+    m_packet_drop_hook_generic = std::move(cb);
 }
 
 void FlowControl::set_packet_transmit_hook(PacketTransmitHook::callback_type&& cb)
@@ -174,9 +174,9 @@ void FlowControl::set_packet_transmit_hook(PacketTransmitHook::callback_type&& c
     m_packet_transmit_hook = std::move(cb);
 }
 
-void FlowControl::set_packet_transmit_hook(PacketTransmitHookPort::callback_type&& cb)
+void FlowControl::set_packet_transmit_hook(PacketTransmitHookGeneric::callback_type&& cb)
 {
-    m_packet_transmit_hook_port = std::move(cb);
+    m_packet_transmit_hook_generic = std::move(cb);
 }
 
 void FlowControl::queue_length(std::size_t length)
@@ -193,16 +193,14 @@ void FlowControl::reschedule()
     }
 }
 
-void FlowControl::call_drop_hooks(AccessCategory ac, ChunkPacket& packet) {
-    auto btp_header = vanetza::btp::parse_btp_b(packet);
+void FlowControl::call_drop_hooks(AccessCategory ac, const ChunkPacket& packet) {
     m_packet_drop_hook(ac);
-    m_packet_drop_hook_port(btp_header.destination_port);
+    m_packet_drop_hook_generic(packet);
 }
 
-void FlowControl::call_transmit_hooks(AccessCategory ac, ChunkPacket& packet) {
-    auto btp_header = vanetza::btp::parse_btp_b(packet);
+void FlowControl::call_transmit_hooks(AccessCategory ac, const ChunkPacket& packet) {
     m_packet_transmit_hook(ac);
-    m_packet_transmit_hook_port(btp_header.destination_port);
+    m_packet_transmit_hook_generic(packet);
 }
 
 } // namespace dcc

--- a/vanetza/dcc/flow_control.hpp
+++ b/vanetza/dcc/flow_control.hpp
@@ -1,6 +1,7 @@
 #ifndef FLOW_CONTROL_HPP_PG7RKD8V
 #define FLOW_CONTROL_HPP_PG7RKD8V
 
+#include <vanetza/btp/header.hpp>
 #include <vanetza/common/clock.hpp>
 #include <vanetza/common/hook.hpp>
 #include <vanetza/dcc/data_request.hpp>
@@ -38,7 +39,9 @@ class FlowControl : public RequestInterface
 {
 public:
     using PacketDropHook = Hook<AccessCategory>;
+    using PacketDropHookPort = Hook<vanetza::btp::port_type>;
     using PacketTransmitHook = Hook<AccessCategory>;
+    using PacketTransmitHookPort = Hook<vanetza::btp::port_type>;
 
     /**
      * Create FlowControl instance
@@ -63,10 +66,22 @@ public:
     void set_packet_drop_hook(PacketDropHook::callback_type&&);
 
     /**
+     * Set callback to be invoked at packet drop. Replaces any previous callback.
+     * \param cb Callback
+     */
+    void set_packet_drop_hook(PacketDropHookPort::callback_type&&);
+
+    /**
      * Set callback to be invoked at packet transmission. Replaces any previous callback.
      * \param cb Callback
      */
     void set_packet_transmit_hook(PacketTransmitHook::callback_type&&);
+
+    /**
+     * Set callback to be invoked at packet transmission. Replaces any previous callback.
+     * \param cb Callback
+     */
+    void set_packet_transmit_hook(PacketTransmitHookPort::callback_type&&);
 
     /**
      * Set length of each queue
@@ -109,6 +124,8 @@ private:
     void schedule_trigger(const Transmission&);
     PendingTransmission* next_transmission();
     Queue* next_queue();
+    void call_drop_hooks(AccessCategory ac, ChunkPacket& packet);
+    void call_transmit_hooks(AccessCategory ac, ChunkPacket& packet);
 
     Runtime& m_runtime;
     TransmitRateControl& m_trc;
@@ -116,7 +133,9 @@ private:
     std::map<AccessCategory, Queue, std::greater<AccessCategory>> m_queues;
     std::size_t m_queue_length;
     PacketDropHook m_packet_drop_hook;
+    PacketDropHookPort m_packet_drop_hook_port;
     PacketTransmitHook m_packet_transmit_hook;
+    PacketTransmitHookPort m_packet_transmit_hook_port;
 };
 
 } // namespace dcc

--- a/vanetza/dcc/flow_control.hpp
+++ b/vanetza/dcc/flow_control.hpp
@@ -1,7 +1,6 @@
 #ifndef FLOW_CONTROL_HPP_PG7RKD8V
 #define FLOW_CONTROL_HPP_PG7RKD8V
 
-#include <vanetza/btp/header.hpp>
 #include <vanetza/common/clock.hpp>
 #include <vanetza/common/hook.hpp>
 #include <vanetza/dcc/data_request.hpp>
@@ -39,9 +38,9 @@ class FlowControl : public RequestInterface
 {
 public:
     using PacketDropHook = Hook<AccessCategory>;
-    using PacketDropHookPort = Hook<vanetza::btp::port_type>;
+    using PacketDropHookGeneric = Hook<const ChunkPacket&>;
     using PacketTransmitHook = Hook<AccessCategory>;
-    using PacketTransmitHookPort = Hook<vanetza::btp::port_type>;
+    using PacketTransmitHookGeneric = Hook<const ChunkPacket&>;
 
     /**
      * Create FlowControl instance
@@ -69,7 +68,7 @@ public:
      * Set callback to be invoked at packet drop. Replaces any previous callback.
      * \param cb Callback
      */
-    void set_packet_drop_hook(PacketDropHookPort::callback_type&&);
+    void set_packet_drop_hook(PacketDropHookGeneric::callback_type&&);
 
     /**
      * Set callback to be invoked at packet transmission. Replaces any previous callback.
@@ -81,7 +80,7 @@ public:
      * Set callback to be invoked at packet transmission. Replaces any previous callback.
      * \param cb Callback
      */
-    void set_packet_transmit_hook(PacketTransmitHookPort::callback_type&&);
+    void set_packet_transmit_hook(PacketTransmitHookGeneric::callback_type&&);
 
     /**
      * Set length of each queue
@@ -124,8 +123,8 @@ private:
     void schedule_trigger(const Transmission&);
     PendingTransmission* next_transmission();
     Queue* next_queue();
-    void call_drop_hooks(AccessCategory ac, ChunkPacket& packet);
-    void call_transmit_hooks(AccessCategory ac, ChunkPacket& packet);
+    void call_drop_hooks(AccessCategory ac, const ChunkPacket& packet);
+    void call_transmit_hooks(AccessCategory ac, const ChunkPacket& packet);
 
     Runtime& m_runtime;
     TransmitRateControl& m_trc;
@@ -133,9 +132,9 @@ private:
     std::map<AccessCategory, Queue, std::greater<AccessCategory>> m_queues;
     std::size_t m_queue_length;
     PacketDropHook m_packet_drop_hook;
-    PacketDropHookPort m_packet_drop_hook_port;
+    PacketDropHookGeneric m_packet_drop_hook_generic;
     PacketTransmitHook m_packet_transmit_hook;
-    PacketTransmitHookPort m_packet_transmit_hook_port;
+    PacketTransmitHookGeneric m_packet_transmit_hook_generic;
 };
 
 } // namespace dcc


### PR DESCRIPTION
For some of our simulations we needed to distinguish packets dropped by the gatekeeper. The existing drop/transmit hooks are only useful if all running applications have different access categories which does not necessarily have to be the case. This downward compatible PR adds hooks reporting the BTP-B destination port which should indeed always be different for different applications. It also wraps the calls of the hooks, keeping the code of the gate keeper's core funtions tidy -- even if more hooks would be added in the future.