### PR TITLE
socktap: create helper function to copy position information into CAM

### DIFF
--- a/tools/socktap/cam_application.cpp
+++ b/tools/socktap/cam_application.cpp
@@ -16,15 +16,6 @@ using namespace vanetza;
 using namespace vanetza::facilities;
 using namespace std::chrono;
 
-auto microdegree = vanetza::units::degree * boost::units::si::micro;
-
-template<typename T, typename U>
-long round(const boost::units::quantity<T>& q, const U& u)
-{
-	boost::units::quantity<U> v { q };
-	return std::round(v.value());
-}
-
 CamApplication::CamApplication(PositionProvider& positioning, const Runtime& rt, boost::asio::steady_timer& timer, milliseconds cam_interval)
     : positioning_(positioning), runtime_(rt), cam_interval_(cam_interval), timer_(timer)
 {
@@ -81,18 +72,7 @@ void CamApplication::on_timer(const boost::system::error_code& ec)
 
     BasicContainer_t& basic = cam.camParameters.basicContainer;
     basic.stationType = StationType_passengerCar;
-    basic.referencePosition.longitude = round(position.longitude, microdegree) * Longitude_oneMicrodegreeEast;
-    basic.referencePosition.latitude = round(position.latitude, microdegree) * Latitude_oneMicrodegreeNorth;
-    basic.referencePosition.positionConfidenceEllipse.semiMajorOrientation = HeadingValue_unavailable;
-    basic.referencePosition.positionConfidenceEllipse.semiMajorConfidence = SemiAxisLength_unavailable;
-    basic.referencePosition.positionConfidenceEllipse.semiMinorConfidence = SemiAxisLength_unavailable;
-    if (position.altitude) {
-        basic.referencePosition.altitude.altitudeValue = to_altitude_value(position.altitude->value());
-        basic.referencePosition.altitude.altitudeConfidence = to_altitude_confidence(position.altitude->confidence());
-    } else {
-        basic.referencePosition.altitude.altitudeValue = AltitudeValue_unavailable;
-        basic.referencePosition.altitude.altitudeConfidence = AltitudeConfidence_unavailable;
-    }
+    copy(position, basic.referencePosition);
 
     cam.camParameters.highFrequencyContainer.present = HighFrequencyContainer_PR_basicVehicleContainerHighFrequency;
 

--- a/vanetza/facilities/cam_functions.cpp
+++ b/vanetza/facilities/cam_functions.cpp
@@ -22,12 +22,14 @@ namespace facilities
 
 using vanetza::units::Angle;
 
+static const auto microdegree = units::degree * units::si::micro;
+
 // TODO:  C2C-CC BSP allows up to 500m history for CAMs, we provide just minimal required history
 void copy(const facilities::PathHistory& ph, BasicVehicleContainerLowFrequency& container)
 {
     static const std::size_t scMaxPathPoints = 23;
     static const boost::posix_time::time_duration scMaxDeltaTime = boost::posix_time::millisec(655350);
-    static const auto scMicrodegree = units::si::micro * units::degree;
+    static const auto scMicrodegree = microdegree;
 
     const auto& concise_points = ph.getConcisePoints();
     const facilities::PathPoint& ref = ph.getReferencePoint();
@@ -97,18 +99,16 @@ units::Length distance(const ReferencePosition_t& a, const ReferencePosition_t& 
 {
     using geonet::GeodeticPosition;
     using units::GeoAngle;
-    using boost::units::si::micro;
-    using boost::units::degree::degree;
 
     auto length = units::Length::from_value(std::numeric_limits<double>::quiet_NaN());
     if (is_available(a) && is_available(b)) {
         GeodeticPosition geo_a {
-            GeoAngle { a.latitude / Latitude_oneMicrodegreeNorth * micro * degree },
-            GeoAngle { a.longitude / Longitude_oneMicrodegreeEast * micro * degree }
+            GeoAngle { a.latitude / Latitude_oneMicrodegreeNorth * microdegree },
+            GeoAngle { a.longitude / Longitude_oneMicrodegreeEast * microdegree }
         };
         GeodeticPosition geo_b {
-            GeoAngle { b.latitude / Latitude_oneMicrodegreeNorth * micro * degree },
-            GeoAngle { b.longitude / Longitude_oneMicrodegreeEast * micro * degree }
+            GeoAngle { b.latitude / Latitude_oneMicrodegreeNorth * microdegree },
+            GeoAngle { b.longitude / Longitude_oneMicrodegreeEast * microdegree }
         };
         length = geonet::distance(geo_a, geo_b);
     }
@@ -119,14 +119,12 @@ units::Length distance(const ReferencePosition_t& a, units::GeoAngle lat, units:
 {
     using geonet::GeodeticPosition;
     using units::GeoAngle;
-    using boost::units::si::micro;
-    using boost::units::degree::degree;
 
     auto length = units::Length::from_value(std::numeric_limits<double>::quiet_NaN());
     if (is_available(a)) {
         GeodeticPosition geo_a {
-            GeoAngle { a.latitude / Latitude_oneMicrodegreeNorth * micro * degree },
-            GeoAngle { a.longitude / Longitude_oneMicrodegreeEast * micro * degree }
+            GeoAngle { a.latitude / Latitude_oneMicrodegreeNorth * microdegree },
+            GeoAngle { a.longitude / Longitude_oneMicrodegreeEast * microdegree }
         };
         GeodeticPosition geo_b { lat, lon };
         length = geonet::distance(geo_a, geo_b);
@@ -142,6 +140,29 @@ bool is_available(const Heading& hd)
 bool is_available(const ReferencePosition& pos)
 {
     return pos.latitude != Latitude_unavailable && pos.longitude != Longitude_unavailable;
+}
+
+
+template<typename T, typename U>
+long round(const boost::units::quantity<T>& q, const U& u)
+{
+    boost::units::quantity<U> v { q };
+    return std::round(v.value());
+}
+
+void copy(const PositionFix& position, ReferencePosition& reference_position) {
+    reference_position.longitude = round(position.longitude, microdegree) * Longitude_oneMicrodegreeEast;
+    reference_position.latitude = round(position.latitude, microdegree) * Latitude_oneMicrodegreeNorth;
+    reference_position.positionConfidenceEllipse.semiMajorOrientation = HeadingValue_unavailable;
+    reference_position.positionConfidenceEllipse.semiMajorConfidence = SemiAxisLength_unavailable;
+    reference_position.positionConfidenceEllipse.semiMinorConfidence = SemiAxisLength_unavailable;
+    if (position.altitude) {
+        reference_position.altitude.altitudeValue = to_altitude_value(position.altitude->value());
+        reference_position.altitude.altitudeConfidence = to_altitude_confidence(position.altitude->confidence());
+    } else {
+        reference_position.altitude.altitudeValue = AltitudeValue_unavailable;
+        reference_position.altitude.altitudeConfidence = AltitudeConfidence_unavailable;
+    }
 }
 
 AltitudeConfidence_t to_altitude_confidence(units::Length confidence)

--- a/vanetza/facilities/cam_functions.hpp
+++ b/vanetza/facilities/cam_functions.hpp
@@ -5,6 +5,7 @@
 #include <vanetza/asn1/its/AltitudeValue.h>
 #include <vanetza/asn1/its/Heading.h>
 #include <vanetza/asn1/its/ReferencePosition.h>
+#include <vanetza/common/position_fix.hpp>
 #include <vanetza/security/cam_ssp.hpp>
 #include <vanetza/units/angle.hpp>
 #include <vanetza/units/length.hpp>
@@ -58,12 +59,17 @@ bool is_available(const Heading&);
 bool is_available(const ReferencePosition_t&);
 
 /**
+ * Copy position information into a ReferencePosition structure from CDD
+ */
+void copy(const PositionFix&, ReferencePosition&);
+
+/**
  * Convert altitude to AltitudeValue from CDD
  */
 AltitudeValue_t to_altitude_value(units::Length);
 
 /**
- * Convert altitude confidencet to AltitudeConfidence from CDD
+ * Convert altitude confidence to AltitudeConfidence from CDD
  */
 AltitudeConfidence_t to_altitude_confidence(units::Length);
 


### PR DESCRIPTION
This PR moves the code that fills a CAM's `ReferencePosition` with the information from a `PositionFix` to `cam_functions.hpp/.cpp` and reuses `cam_functions`'s unit for latitude/longitude in CAMs. Also, see [this comment](https://github.com/riebl/vanetza/pull/91#discussion_r330111263).