### PR TITLE
Miscellaneous small improvements for socktap, btp and geonet

### DIFF
--- a/tools/socktap/dcc_passthrough.cpp
+++ b/tools/socktap/dcc_passthrough.cpp
@@ -6,6 +6,7 @@
 #include <vanetza/net/chunk_packet.hpp>
 #include <boost/asio/generic/raw_protocol.hpp>
 #include <iostream>
+#include <sstream>
 
 #ifdef SOCKTAP_WITH_COHDA_LLC
 #include "cohda.hpp"
@@ -43,7 +44,9 @@ void DccPassthrough::request(const dcc::DataRequest& request, std::unique_ptr<Ch
         const_buffers[i] = asio::buffer(buffers_[i]);
     }
     auto bytes_sent = socket_.send(const_buffers);
-    std::cout << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
+    std::ostringstream ostream;
+    ostream << "sent packet to " << request.destination << " (" << bytes_sent << " bytes)\n";
+    std::cout << ostream.str();
 }
 
 void DccPassthrough::allow_packet_flow(bool allow)

--- a/tools/socktap/main_cam.cpp
+++ b/tools/socktap/main_cam.cpp
@@ -43,6 +43,7 @@ int main(int argc, const char** argv)
         ("print-rx-cam", "Print received CAMs")
         ("print-tx-cam", "Print generated CAMs")
         ("benchmark", "Enable benchmarking")
+        ("non-strict", "Set MIB parameter ItsGnSnDecapResultHandling to NON_STRICT")
     ;
 
     po::positional_options_description positional_options;
@@ -107,6 +108,9 @@ int main(int argc, const char** argv)
         mib.itsGnLocalGnAddr.is_manually_configured(true);
         mib.itsGnLocalAddrConfMethod = geonet::AddrConfMethod::Managed;
         mib.itsGnSecurity = false;
+        if (vm.count("non-strict")) {
+            mib.itsGnSnDecapResultHandling = vanetza::geonet::SecurityDecapHandling::Non_Strict;
+        }
         mib.itsGnProtocolVersion = vm["gn-version"].as<unsigned>();
 
         if (mib.itsGnProtocolVersion != 0 && mib.itsGnProtocolVersion != 1) {

--- a/tools/socktap/main_cam.cpp
+++ b/tools/socktap/main_cam.cpp
@@ -148,6 +148,7 @@ int main(int argc, const char** argv)
                 for (auto& chain_path : vm["certificate-chain"].as<std::vector<std::string> >()) {
                     auto chain_certificate = security::load_certificate_from_file(chain_path);
                     chain.push_back(chain_certificate);
+                    cert_cache.insert(chain_certificate);
 
                     // Only add root certificates to trust store, so certificate requests are visible for demo purposes.
                     if (chain_certificate.subject_info.subject_type == security::SubjectType::Root_CA) {

--- a/tools/socktap/main_cam.cpp
+++ b/tools/socktap/main_cam.cpp
@@ -177,7 +177,7 @@ int main(int argc, const char** argv)
         security::VerifyService verify_service = straight_verify_service(trigger.runtime(), *certificate_provider, *certificate_validator, *crypto_backend, cert_cache, sign_header_policy, positioning);
 
         security::DelegatingSecurityEntity security_entity(sign_service, verify_service);
-        RouterContext context(raw_socket, mib, trigger, positioning, security_entity);
+        RouterContext context(raw_socket, mib, trigger, positioning, &security_entity);
         context.require_position_fix(vm.count("require-gnss-fix") > 0);
 
         CamApplication cam_app(positioning, trigger.runtime());

--- a/tools/socktap/main_hello.cpp
+++ b/tools/socktap/main_hello.cpp
@@ -98,7 +98,7 @@ int main(int argc, const char** argv)
             security::dummy_verify_service(security::VerificationReport::Success, security::CertificateValidity::valid());
         security::DelegatingSecurityEntity security_entity(sign_service, verify_service);
 
-        RouterContext context(raw_socket, mib, trigger, positioning, security_entity);
+        RouterContext context(raw_socket, mib, trigger, positioning, &security_entity);
         context.require_position_fix(vm.count("require-gnss-fix") > 0);
 
         asio::steady_timer hello_timer(io_service);

--- a/tools/socktap/router_context.cpp
+++ b/tools/socktap/router_context.cpp
@@ -40,7 +40,7 @@ RouterContext::RouterContext(raw_protocol::socket& socket, const geonet::MIB& mi
 RouterContext::~RouterContext()
 {
     for (auto* app : applications_) {
-        app->router_ = nullptr;
+        disable(app);
     }
 }
 
@@ -101,6 +101,16 @@ void RouterContext::enable(Application* app)
     if (app->port() != btp::port_type(0)) {
         dispatcher_.set_non_interactive_handler(app->port(), app);
     }
+}
+
+void RouterContext::disable(Application* app)
+{
+    if (app->port() != btp::port_type(0)) {
+        dispatcher_.set_non_interactive_handler(app->port(), nullptr);
+    }
+    dispatcher_.remove_promiscuous_hook(app->promiscuous_hook());
+
+    app->router_ = nullptr;
 }
 
 void RouterContext::require_position_fix(bool flag)

--- a/tools/socktap/router_context.cpp
+++ b/tools/socktap/router_context.cpp
@@ -10,6 +10,7 @@
 #include <boost/asio/generic/raw_protocol.hpp>
 #include <boost/optional/optional.hpp>
 #include <iostream>
+#include <sstream>
 #include <vanetza/common/byte_order.hpp>
 
 #ifdef SOCKTAP_WITH_COHDA_LLC
@@ -47,7 +48,9 @@ RouterContext::~RouterContext()
 void RouterContext::log_packet_drop(geonet::Router::PacketDropReason reason)
 {
     auto reason_string = stringify(reason);
-    std::cout << "Router dropped packet because of " << reason_string << " (" << static_cast<int>(reason) << ")\n";
+    std::ostringstream ostream;
+    ostream << "Router dropped packet because of " << reason_string << " (" << static_cast<int>(reason) << ")\n";
+    std::cout << ostream.str();
 }
 
 void RouterContext::do_receive()
@@ -84,7 +87,10 @@ void RouterContext::pass_up(CohesivePacket&& packet)
         EthernetHeader hdr = decode_ethernet_header(link_range.begin(), link_range.end());
 #endif
         if (hdr.source != mib_.itsGnLocalGnAddr.mid() && hdr.type == access::ethertype::GeoNetworking) {
-            std::cout << "received packet from " << hdr.source << " (" << packet.size() << " bytes)\n";
+            std::ostringstream ostream;
+            ostream << "received packet from " << hdr.source << " (" << packet.size() << " bytes)\n";
+            std::cout << ostream.str();
+
             std::unique_ptr<PacketVariant> up { new PacketVariant(std::move(packet)) };
             trigger_.schedule(); // ensure the clock is up-to-date for the security entity
             router_.indicate(std::move(up), hdr.source, hdr.destination);

--- a/tools/socktap/router_context.cpp
+++ b/tools/socktap/router_context.cpp
@@ -20,7 +20,7 @@ namespace asio = boost::asio;
 using boost::asio::generic::raw_protocol;
 using namespace vanetza;
 
-RouterContext::RouterContext(raw_protocol::socket& socket, const geonet::MIB& mib, TimeTrigger& trigger, vanetza::PositionProvider& positioning, vanetza::security::SecurityEntity& security_entity) :
+RouterContext::RouterContext(raw_protocol::socket& socket, const geonet::MIB& mib, TimeTrigger& trigger, vanetza::PositionProvider& positioning, vanetza::security::SecurityEntity* security_entity) :
     mib_(mib), router_(trigger.runtime(), mib_),
     socket_(socket), trigger_(trigger), positioning_(positioning),
     request_interface_(new DccPassthrough(socket, trigger)),
@@ -30,7 +30,7 @@ RouterContext::RouterContext(raw_protocol::socket& socket, const geonet::MIB& mi
     router_.set_address(mib_.itsGnLocalGnAddr);
     router_.set_access_interface(request_interface_.get());
     router_.set_transport_handler(geonet::UpperProtocol::BTP_B, &dispatcher_);
-    router_.set_security_entity(&security_entity);
+    router_.set_security_entity(security_entity);
     update_position_vector();
 
     do_receive();

--- a/tools/socktap/router_context.hpp
+++ b/tools/socktap/router_context.hpp
@@ -19,7 +19,7 @@ class TimeTrigger;
 class RouterContext
 {
 public:
-    RouterContext(boost::asio::generic::raw_protocol::socket&, const vanetza::geonet::MIB&, TimeTrigger&, vanetza::PositionProvider&, vanetza::security::SecurityEntity&);
+    RouterContext(boost::asio::generic::raw_protocol::socket&, const vanetza::geonet::MIB&, TimeTrigger&, vanetza::PositionProvider&, vanetza::security::SecurityEntity*);
     ~RouterContext();
     void enable(Application*);
     void disable(Application*);

--- a/tools/socktap/router_context.hpp
+++ b/tools/socktap/router_context.hpp
@@ -22,6 +22,7 @@ public:
     RouterContext(boost::asio::generic::raw_protocol::socket&, const vanetza::geonet::MIB&, TimeTrigger&, vanetza::PositionProvider&, vanetza::security::SecurityEntity&);
     ~RouterContext();
     void enable(Application*);
+    void disable(Application*);
 
     /**
      * Allow/disallow transmissions without GNSS position fix

--- a/vanetza/btp/port_dispatcher.cpp
+++ b/vanetza/btp/port_dispatcher.cpp
@@ -38,6 +38,13 @@ void PortDispatcher::add_promiscuous_hook(PromiscuousHook* hook)
     }
 }
 
+void PortDispatcher::remove_promiscuous_hook(PromiscuousHook* hook)
+{
+    if (hook != nullptr) {
+        m_promiscuous_hooks.remove(hook);
+    }
+}
+
 void PortDispatcher::set_interactive_handler(
         port_type port,
         IndicationInterface* handler)

--- a/vanetza/btp/port_dispatcher.hpp
+++ b/vanetza/btp/port_dispatcher.hpp
@@ -55,6 +55,11 @@ public:
      */
     void add_promiscuous_hook(PromiscuousHook*);
 
+    /**
+     * Remove a hook
+     */
+    void remove_promiscuous_hook(PromiscuousHook*);
+
     // Implementation of geonet::TransportInterface
     void indicate(const geonet::DataIndication&, std::unique_ptr<UpPacket>) override;
 

--- a/vanetza/geonet/router.cpp
+++ b/vanetza/geonet/router.cpp
@@ -398,7 +398,6 @@ void Router::indicate_basic(IndicationContextBasic& ctx)
             indicate_secured(ctx, *basic);
         } else if (basic->next_header == NextHeaderBasic::Common) {
             if (!m_mib.itsGnSecurity || SecurityDecapHandling::Non_Strict == m_mib.itsGnSnDecapResultHandling) {
-                indication.security_report = security::DecapReport::Unsigned_Message,
                 indicate_common(ctx, *basic);
             } else {
                 packet_dropped(PacketDropReason::Decap_Unsuccessful_Strict);


### PR DESCRIPTION
This PR is a collection of different small improvements for btp, geonet, socktap.

- BTP: Added hooks can now be removed again.
- GN: The security report is only initialized when the security entity has actually been invoked.
- Socktap:
    - Applications can be disabled again (combined with the BTP change, one can close ports in both directions).
    - Status messages are assembled separately and then printed to `std::cout` as one string.
    - AA certificates provided via commandline are put into the certificate cache so if other stations use the same AA, the certificate does not need to be requested from them.
    - New command line parameter to control MIB parameter `ItnGnSnDecapResultHandling`.
    - Make the `SecurityEntity` parameter of `RouterContext`'s constructor a pointer to conform with the interface/requirements of `Router`.