### PR TITLE
Fix and new feature (dual alpha) for LIMERIC 

### DIFF
--- a/vanetza/dcc/limeric.cpp
+++ b/vanetza/dcc/limeric.cpp
@@ -57,6 +57,12 @@ UnitInterval Limeric::calculate_duty_cycle() const
     }
     UnitInterval delta = m_params.alpha.complement() * m_duty_cycle + delta_offset;
     delta = std::min(std::max(delta, m_params.delta_min), m_params.delta_max);
+
+    if(m_params.useDualAlpha && m_duty_cycle - delta > m_params.th) {
+        delta = m_params.alphaHigh.complement() * m_duty_cycle + delta_offset;
+        delta = std::min(std::max(delta, m_params.delta_min), m_params.delta_max);
+    }
+
     return delta;
 }
 

--- a/vanetza/dcc/limeric.hpp
+++ b/vanetza/dcc/limeric.hpp
@@ -28,6 +28,8 @@ class Limeric : public DutyCyclePermit
 public:
     /**
      * Limeric paremeters as given by TS 102 687 v1.2.1, Table 3
+     *  Reference for Dual-alpha Limeric:
+     *     "Strength and Weaknesses of the ETSI Adaptive DCC Algorithm: A Proposal for Improvement"
      */
     struct Parameters
     {
@@ -39,6 +41,9 @@ public:
         double g_minus_max = -0.00025;
         ChannelLoad cbr_target { 0.68 };
         Clock::duration cbr_interval = std::chrono::milliseconds(100); /*< algorithm is scheduled every second interval */
+        bool useDualAlpha = false;
+        UnitInterval alphaHigh { 0.1 }; /*< Alpha used when delta is decreasing between two updating steps */
+        UnitInterval th { 0.00001 }; /*<  Determined heuristically */
     };
 
     Limeric(Runtime&);

--- a/vanetza/dcc/limeric_budget.cpp
+++ b/vanetza/dcc/limeric_budget.cpp
@@ -44,13 +44,16 @@ void LimericBudget::notify(Clock::duration tx_on)
 
 void LimericBudget::update()
 {
-    // Apply equation B.2 of TS 102 687 v1.2.1
+     // Apply equation B.2 of TS 102 687 v1.2.1
     using std::chrono::duration_cast;
     using FloatingPointDuration = std::chrono::duration<double, Clock::period>;
     const FloatingPointDuration delay = m_tx_start + m_interval - m_runtime.now();
-    const auto duty_cycle = m_duty_cycle_permit.permitted_duty_cycle();
-    const FloatingPointDuration interval = (m_tx_on / duty_cycle.value()) * (delay / m_interval);
-    m_interval = clamp_interval(duration_cast<Clock::duration>(interval) + m_runtime.now() - m_tx_start);
+
+    if(std::chrono::duration_cast<std::chrono::microseconds>(delay).count() > 0){
+        const auto duty_cycle = m_duty_cycle_permit.permitted_duty_cycle();
+        const FloatingPointDuration interval = (m_tx_on / duty_cycle.value()) * (delay / m_interval);
+        m_interval = clamp_interval(duration_cast<Clock::duration>(interval) + m_runtime.now() - m_tx_start);
+    }
 }
 
 Clock::duration LimericBudget::clamp_interval(Clock::duration interval) const


### PR DESCRIPTION
Hello :) 
This pull request consists on two different things:
- The fix: Avoid to keep updating m_interval when this one is already "expired". The problem comes when the variable delay is lower than 0, the m_interval is not consistent anymore.

- The new feature: To reduce the convergence time of LIMERIC in transition period, a paper (https://ieeexplore.ieee.org/document/8671471) proposes to use a Dual-Alpha approach. This is what I implemented.

Regards,
Q.