### PR TITLE
Return left hand side in move assignment operator for `asn1c_wrapper_common`

### DIFF
--- a/vanetza/asn1/asn1c_wrapper.hpp
+++ b/vanetza/asn1/asn1c_wrapper.hpp
@@ -57,7 +57,11 @@ public:
     // move semantics
     asn1c_wrapper_common(asn1c_wrapper_common&& other) noexcept :
         m_struct(nullptr), m_type(other.m_type) { swap(other); }
-    asn1c_wrapper_common& operator=(asn1c_wrapper_common&& other) noexcept { swap(other); }
+    asn1c_wrapper_common& operator=(asn1c_wrapper_common&& other) noexcept
+    {
+        swap(other);
+        return *this;
+    }
 
     // dereferencing
     asn1c_type& operator*() { return *m_struct; }


### PR DESCRIPTION
The move assignment operator of `asn1c_wrapper_common` doesn't return a value, but should return the left hand side.