### PR TITLE
socktap: add missing include in cohda header

### DIFF
--- a/tools/socktap/cohda.hpp
+++ b/tools/socktap/cohda.hpp
@@ -7,6 +7,7 @@
 #include <vanetza/common/clock.hpp>
 #include <vanetza/net/chunk_packet.hpp>
 #include <vanetza/net/cohesive_packet.hpp>
+#include <vanetza/net/ethernet_header.hpp>
 
 namespace vanetza
 {


### PR DESCRIPTION
Plain and simple: the header `cohda.hpp` is missing the include statement for `ethernet_header.hpp`.