### PR TITLE
cmake: fix build with GeographicLib source code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(Vanetza VERSION 0.8)
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
 # enable convenient CMake policies if available
 if(POLICY CMP0074)

--- a/vanetza/geonet/CMakeLists.txt
+++ b/vanetza/geonet/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CXX_SOURCES
 )
 
 add_vanetza_component(geonet ${CXX_SOURCES})
-target_link_libraries(geonet PRIVATE GeographicLib::GeographicLib)
+target_link_libraries(geonet PRIVATE ${GeographicLib_LIBRARIES})
 target_link_libraries(geonet PUBLIC Boost::date_time)
 target_link_libraries(geonet PUBLIC dcc net security)
 

--- a/vanetza/security/CMakeLists.txt
+++ b/vanetza/security/CMakeLists.txt
@@ -37,7 +37,7 @@ add_vanetza_component(security
     verify_service.cpp
 )
 target_link_libraries(security PUBLIC common net)
-target_link_libraries(security PRIVATE GeographicLib::GeographicLib)
+target_link_libraries(security PRIVATE ${GeographicLib_LIBRARIES})
 
 # crypto++ is a public mandatory dependency because of "NaiveCertificateProvider"
 if(TARGET CryptoPP::CryptoPP)


### PR DESCRIPTION
Hello,
I would like to build Vanetza with GeographicLib source code.
In my project Vanetza and GeographicLib are both submodules.
I manage to do it with this patch but I am not sure this is the correct way.
Please, if my method is not correct, could you give a sample CMakeLists.txt file to build
both projects?
Thank you
Best regards.
PS: I am using ubuntu 18.04 and geographicLib 1.49.2