### PR TITLE
asn1: fix LanePosition in CDD from TS 102 894-2 v1.3.1

### DIFF
--- a/asn1/TS102894-2v131-CDD.asn
+++ b/asn1/TS102894-2v131-CDD.asn
@@ -213,8 +213,8 @@ HeadingValue ::= INTEGER {wgs84North(0), wgs84East(900), wgs84South(1800), wgs84
 
 HeadingConfidence ::= INTEGER {equalOrWithinZeroPointOneDegree (1), equalOrWithinOneDegree (10), outOfRange(126), unavailable(127)} (1..127)
 
-LanePosition::= INTEGER {offTheRoad(-1), hardShoulder(0),
-outermostDrivingLane(1), secondLaneFromOutside(2)} (-1..14)
+LanePosition::= INTEGER {offTheRoad(-1), innerHardShoulder(0),
+innermostDrivingLane(1), secondLaneFromInside(2), outerHardShoulder(14) } (-1..14)
 
 ClosedLanes ::= SEQUENCE {
     innerhardShoulderStatus HardShoulderStatus OPTIONAL,

--- a/vanetza/asn1/its/LanePosition.h
+++ b/vanetza/asn1/its/LanePosition.h
@@ -21,9 +21,10 @@ extern "C" {
 /* Dependencies */
 typedef enum LanePosition {
 	LanePosition_offTheRoad	= -1,
-	LanePosition_hardShoulder	= 0,
-	LanePosition_outermostDrivingLane	= 1,
-	LanePosition_secondLaneFromOutside	= 2
+	LanePosition_innerHardShoulder	= 0,
+	LanePosition_innermostDrivingLane	= 1,
+	LanePosition_secondLaneFromInside	= 2,
+	LanePosition_outerHardShoulder	= 14
 } e_LanePosition;
 
 /* LanePosition */


### PR DESCRIPTION
Hello,
In the TS 102 894-2 v1.3.1 there are 2 different descriptions of the LanePosition field.
The first p41 tells: innerHardShoulder(0), innermostDrivingLane(1)
The second p94 tells: hardShoulder(0), outermostDrivingLane(1)
It seems that the correct description is Lane 0 as the innerHardShoulder and the 1st lane as the innermostDrivingLane.
https://forge.etsi.org/rep/ITS/asn1/cdd_ts102894_2 confirms this.
This commit modifies the LanePosition as on etsi git repository
Best regards.
