### PR TITLE
socktap: fetch altitude for GPSD_API_MAJOR_VERSION > 8

### DIFF
--- a/tools/socktap/gps_position_provider.cpp
+++ b/tools/socktap/gps_position_provider.cpp
@@ -147,7 +147,11 @@ void GpsPositionProvider::fetch_position_fix()
             fetched_position_fix.confidence = vanetza::PositionConfidence();
         }
         if (gps_data.fix.mode == MODE_3D) {
+#if GPSD_API_MAJOR_VERSION > 8
+            fetched_position_fix.altitude = vanetza::ConfidentQuantity<vanetza::units::Length>(gps_data.fix.altHAE * si::meter, gps_data.fix.epv * si::meter);
+#else
             fetched_position_fix.altitude = vanetza::ConfidentQuantity<vanetza::units::Length>(gps_data.fix.altitude * si::meter, gps_data.fix.epv * si::meter);
+#endif
         } else {
             fetched_position_fix.altitude = boost::none;
         }


### PR DESCRIPTION
"altitude" variable is deprecated after GPSD_API_MAJOR_VERSION = 8.
Rather "altHAE" (height above ellipsoid) or "altMSL" (mean sea level) is used.

According to ETSI TS 102 894-2 V1.3.1 (2018-08), height above ellipsoid is used in data frames.
