### PR TITLE
Update ports.hpp and its_aid.hpp

### DIFF
--- a/vanetza/btp/ports.hpp
+++ b/vanetza/btp/ports.hpp
@@ -13,7 +13,7 @@ typedef uint16be_t port_type;
 namespace ports
 {
 
-// Port numbers according to ETSI TS 103 248 v1.3.1 (2019-04)
+// Port numbers according to ETSI TS 103 248 v2.1.1 (2021-08)
 static const port_type CAM = host_cast<uint16_t>(2001);
 static const port_type DENM = host_cast<uint16_t>(2002);
 static const port_type TOPO = host_cast<uint16_t>(2003);
@@ -35,6 +35,8 @@ static const port_type CTLM = host_cast<uint16_t>(2014);
 static const port_type CRLM = host_cast<uint16_t>(2015);
 static const port_type EC_AT_REQUEST = host_cast<uint16_t>(2016);
 static const port_type MCDM = host_cast<uint16_t>(2017);
+static const port_type VAM = host_cast<uint16_t>(2018);
+static const port_type IMZM = host_cast<uint16_t>(2019);
 
 } // namespace ports
 

--- a/vanetza/common/its_aid.hpp
+++ b/vanetza/common/its_aid.hpp
@@ -14,7 +14,7 @@ namespace aid
 
 /**
  * ITS-AID assigned for ETSI ITS
- * \see TS 102 965 V1.5.1 Annex A
+ * \see TS 102 965 V2.1.1 Annex A
  */
 constexpr ItsAid CA = 36;
 constexpr ItsAid DEN = 37;
@@ -29,6 +29,7 @@ constexpr ItsAid SCR = 623;
 constexpr ItsAid CTL = 624;
 constexpr ItsAid VRU = 638;
 constexpr ItsAid CP = 639;
+constexpr ItsAid IMZ = 640;
 constexpr ItsAid SA = 540801;
 constexpr ItsAid GPC = 540802;
 constexpr ItsAid IPV6_ROUTING = 270549118;


### PR DESCRIPTION
Update BTP port numbers to latest version of the standard - in ETSI TS 103 248 v2.1.1 there are two more ports defined.
Also, in ETSI TS 102 965 v2.1.1, there is one new ITS-AID for IMZ Service.