### PR TITLE
Adds alternative name for lib to FindGeographiclib

### DIFF
--- a/cmake/FindGeographicLib.cmake
+++ b/cmake/FindGeographicLib.cmake
@@ -11,8 +11,8 @@ endif()
 message(STATUS "GeographicLib: using lookup code by Vanetza")
 
 find_path(GeographicLib_INCLUDE_DIR NAMES GeographicLib/Config.h DOC "GeographicLib include directory")
-find_library(GeographicLib_LIBRARY_RELEASE NAMES Geographic DOC "GeographicLib library (release)")
-find_library(GeographicLib_LIBRARY_DEBUG NAMES Geographic_d DOC "GeographicLib library (debug)")
+find_library(GeographicLib_LIBRARY_RELEASE NAMES Geographic GeographicLib DOC "GeographicLib library (release)")
+find_library(GeographicLib_LIBRARY_DEBUG NAMES Geographic_d GeographicLib_d DOC "GeographicLib library (debug)")
 
 include(SelectLibraryConfigurations)
 select_library_configurations(GeographicLib)


### PR DESCRIPTION
Hi @riebl,
I installed GeographicLib from the Arch User Repository on my system. Unfortunately, it is seems to be named differently now, such that `cmake/FindGeographicLib.cmake` cannot find it anymore.
This small patch adds the name the library has on my system and CMake now finds the library again.
I thought this might help others, too.

Best regards
Keno