### PR TITLE
conan: same dependency versions in conanfile and cmakelists

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,24 +11,37 @@ class VanetzaConan(ConanFile):
         "fPIC": [True, False],
         "shared": [True, False],
         "testing": [True, False],
+        "with_openssl": [True, False],
+        "build_socktap": [True, False],
+        "build_certify": [True, False],
+        "build_benchmark": [True, False]
     }
     default_options = {
         "fPIC": True,
         "shared": False,
         "testing": True,
+        "with_openssl": False,
+        "build_socktap": False,
+        "build_certify": False,
+        "build_benchmark": False
     }
 
     def requirements(self):
         self.requires("boost/[>=1.58]")
         self.requires("cryptopp/[>=5.6.1]")
         self.requires("geographiclib/[>=1.37]")
-        self.requires("openssl/1.1.1i")
+        if self.options.with_openssl :
+            self.requires("openssl/1.1.1i")
 
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.configure(defs={
             "BUILD_SHARED_LIBS": self.options.shared,
             "BUILD_TESTS": self.options.testing,
+            "VANETZA_WITH_OPENSSL": self.options.with_openssl,
+            "BUILD_SOCKTAP": self.options.build_socktap,
+            "BUILD_CERTIFY": self.options.build_certify,
+            "BUILD_BENCHMARK": self.options.build_benchmark,
         })
         return cmake
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,11 +6,6 @@ class VanetzaConan(ConanFile):
     url = "https://github.com/riebl/vanetza"
     license = "LGPL-3.0-or-later"
     settings = "os", "compiler", "build_type", "arch"
-    requires = \
-        "boost/1.75.0", \
-        "cryptopp/8.4.0", \
-        "geographiclib/1.51", \
-        "openssl/1.1.1i"
     generators = "cmake"
     options = {
         "fPIC": [True, False],
@@ -22,6 +17,12 @@ class VanetzaConan(ConanFile):
         "shared": False,
         "testing": True,
     }
+
+    def requirements(self):
+        self.requires("boost/[>=1.58]")
+        self.requires("cryptopp/[>=5.6.1]")
+        self.requires("geographiclib/[>=1.37]")
+        self.requires("openssl/1.1.1i")
 
     def _configure_cmake(self):
         cmake = CMake(self)


### PR DESCRIPTION
This PR includes a simple change in conanfile.py. **_requires_** replaced with **_requirements_** method alternative which could provide a better logic if necessary. The versions of the dependencies changed in a way that give the same meaning with CMakeLists.txt find_package versions.  I have also added into the conanfile.py that the build options which are already exist in CMakeLists.txt.