### PR TITLE
Use boost::asio::post in asynchronous callback in Autotalks link layer

### DIFF
--- a/tools/socktap/autotalks_link.cpp
+++ b/tools/socktap/autotalks_link.cpp
@@ -46,7 +46,7 @@ void AutotalksLink::data_received(uint8_t* pBuf, uint16_t size, v2x_receive_para
     if (callback_ && eth)
     {
         boost::asio::post(io_, [this, packet = std::move(packet), eth]() mutable
-	    {
+        {
             callback_(std::move(packet), *eth);
         });
     }

--- a/tools/socktap/autotalks_link.hpp
+++ b/tools/socktap/autotalks_link.hpp
@@ -11,7 +11,7 @@ public:
     /*
      * Constructor used for device and thread initialization.
      */
-    AutotalksLink(void);
+    AutotalksLink(boost::asio::io_service&);
 
     /*
      * Destructor used for deinitialization.
@@ -25,6 +25,7 @@ private:
     static constexpr std::size_t layers_ = num_osi_layers(vanetza::OsiLayer::Physical, vanetza::OsiLayer::Application);
     IndicationCallback callback_;
     std::array<vanetza::ByteBuffer, layers_> buffers_;
+    boost::asio::io_service& io_;
 };
 
 

--- a/tools/socktap/link_layer.cpp
+++ b/tools/socktap/link_layer.cpp
@@ -92,7 +92,7 @@ create_link_layer(boost::asio::io_service& io_service, const EthernetDevice& dev
 
     } else if (name == "autotalks") {
 #ifdef SOCKTAP_WITH_AUTOTALKS
-        link_layer.reset(new AutotalksLink { });
+        link_layer.reset(new AutotalksLink { io_service });
 #endif
     }
 


### PR DESCRIPTION
I noticed that in Autotalks link layer, sometimes we get the same error as mentioned [here](https://github.com/riebl/vanetza/issues/181#issue-1559609353), so I tried to use `boost::asio::post` as @riebl suggested. This seems to fix the issue but I do not know if it is 100% correct.