### PR TITLE
socktap: fix packet size in TcpLink

### DIFF
--- a/tools/socktap/tcp_link.cpp
+++ b/tools/socktap/tcp_link.cpp
@@ -30,10 +30,7 @@ void TcpLink::request(const access::DataRequest& request, std::unique_ptr<ChunkP
     vanetza::ByteBuffer buffer = create_ethernet_header(request.destination_addr, request.source_addr, request.ether_type);
 
     // insert packet size before ethernet header
-    uint16_t packet_size = packet->size() + EthernetHeader::length_bytes;
-    if (packet->layer(OsiLayer::Link).size() != 0) {
-        packet_size -= packet->layer(OsiLayer::Link).size();
-    }
+    uint16_t packet_size = packet->size(OsiLayer::Network, OsiLayer::Application) + EthernetHeader::length_bytes;
     buffer.insert(buffer.begin(), packet_size & 0x00FF);
     buffer.insert(buffer.begin(), (packet_size & 0xFF00) >> 8);
 

--- a/tools/socktap/tcp_link.cpp
+++ b/tools/socktap/tcp_link.cpp
@@ -31,6 +31,9 @@ void TcpLink::request(const access::DataRequest& request, std::unique_ptr<ChunkP
 
     // insert packet size before ethernet header
     uint16_t packet_size = packet->size() + EthernetHeader::length_bytes;
+    if (packet->layer(OsiLayer::Link).size() != 0) {
+        packet_size -= packet->layer(OsiLayer::Link).size();
+    }
     buffer.insert(buffer.begin(), packet_size & 0x00FF);
     buffer.insert(buffer.begin(), (packet_size & 0xFF00) >> 8);
 


### PR DESCRIPTION
When the router forwards a packet, the packet is duplicated and therefore a link layer is already present.
In this case, the packet-size calculation would count the link layer twice.