### PR TITLE
asn1: Add print() method to asn1c wrapper

### DIFF
--- a/vanetza/asn1/asn1c_wrapper.cpp
+++ b/vanetza/asn1/asn1c_wrapper.cpp
@@ -83,6 +83,11 @@ bool validate(asn_TYPE_descriptor_t& td, const void* t, std::string& error)
     return ok;
 }
 
+int print(FILE* stream, asn_TYPE_descriptor_t& td, const void* t)
+{
+    return asn_fprint(stream, &td, t);
+}
+
 std::size_t size_per(asn_TYPE_descriptor_t& td, const void* t)
 {
     asn_enc_rval_t ec;

--- a/vanetza/asn1/asn1c_wrapper.hpp
+++ b/vanetza/asn1/asn1c_wrapper.hpp
@@ -18,6 +18,7 @@ void free(asn_TYPE_descriptor_t&, void*);
 void* copy(asn_TYPE_descriptor_t&, const void*);
 bool validate(asn_TYPE_descriptor_t&, const void*);
 bool validate(asn_TYPE_descriptor_t&, const void*, std::string&);
+int print(FILE* stream, asn_TYPE_descriptor_t&, const void*);
 std::size_t size_per(asn_TYPE_descriptor_t&, const void*);
 std::size_t size_oer(asn_TYPE_descriptor_t&, const void*);
 ByteBuffer encode_per(asn_TYPE_descriptor_t&, const void*);
@@ -91,6 +92,26 @@ public:
     bool validate(std::string& error) const
     {
         return vanetza::asn1::validate(m_type, m_struct, error);
+    }
+
+    /**
+     * Print ASN.1 type to standard output
+     * \param stream Output stream
+     * \return 0 on success, -1 on error
+     */
+    int print() const 
+    {
+        return vanetza::asn1::print(stdout, m_type, m_struct);
+    }
+
+    /**
+     * Print ASN.1 type to some file stream
+     * \param stream Output stream
+     * \return 0 on success, -1 on error
+     */
+    int print(FILE* stream) const 
+    {
+        return vanetza::asn1::print(stream, m_type, m_struct);
     }
 
     /**

--- a/vanetza/asn1/tests/asn1c_wrapper.cpp
+++ b/vanetza/asn1/tests/asn1c_wrapper.cpp
@@ -56,6 +56,12 @@ TEST(asn1c_wrapper, validate) {
     EXPECT_FALSE(msg.empty());
 }
 
+TEST(asn1c_wrapper, print) {
+    test_wrapper wrapper(asn_DEF_VanetzaTest);
+    OCTET_STRING_fromString(&wrapper->string, "1234");
+    EXPECT_EQ(wrapper.print(), 0);
+}
+
 TEST(asn1c_wrapper, encode) {
     test_wrapper wrapper(asn_DEF_VanetzaTest);
     OCTET_STRING_fromString(&wrapper->string, "1234");


### PR DESCRIPTION
Adds new `print()` method to ASN.1 types by leveraging asn1c's `asn_fprint()`. 
Defaults to `stdout` though the output stream can be specified. Specifying the output is done through a `FILE*`, since there is no straightforward way to convert between an `std::ostream` to a `FILE*`.
Can be regarded as an alternative to CAM's `print_indented()`.