### PR TITLE
asn1: Add compare methods to asn1c wrapper

### DIFF
--- a/vanetza/asn1/asn1c_wrapper.cpp
+++ b/vanetza/asn1/asn1c_wrapper.cpp
@@ -83,6 +83,11 @@ bool validate(asn_TYPE_descriptor_t& td, const void* t, std::string& error)
     return ok;
 }
 
+int compare(asn_TYPE_descriptor_t& td, const void* a, const void* b)
+{
+    return td.op->compare_struct(&td, a, b);
+}
+
 int print(FILE* stream, asn_TYPE_descriptor_t& td, const void* t)
 {
     return asn_fprint(stream, &td, t);

--- a/vanetza/asn1/asn1c_wrapper.hpp
+++ b/vanetza/asn1/asn1c_wrapper.hpp
@@ -75,6 +75,16 @@ public:
     const asn1c_type* content() const { return m_struct; }
     asn1c_type* content() { return m_struct; }
 
+    // compare semantics
+    bool operator==(const asn1c_wrapper_common& rhs) const
+    {
+        return vanetza::asn1::compare(m_type, m_struct, rhs.m_struct) == 0;
+    }
+    bool operator!=(const asn1c_wrapper_common& rhs) const
+    {
+        return vanetza::asn1::compare(m_type, m_struct, rhs.m_struct) != 0;
+    }
+
     /**
      * Check ASN.1 constraints
      * \param error (optional) copy of error message

--- a/vanetza/asn1/asn1c_wrapper.hpp
+++ b/vanetza/asn1/asn1c_wrapper.hpp
@@ -18,6 +18,7 @@ void free(asn_TYPE_descriptor_t&, void*);
 void* copy(asn_TYPE_descriptor_t&, const void*);
 bool validate(asn_TYPE_descriptor_t&, const void*);
 bool validate(asn_TYPE_descriptor_t&, const void*, std::string&);
+int compare(asn_TYPE_descriptor_t&, const void*, const void*);
 int print(FILE* stream, asn_TYPE_descriptor_t&, const void*);
 std::size_t size_per(asn_TYPE_descriptor_t&, const void*);
 std::size_t size_oer(asn_TYPE_descriptor_t&, const void*);
@@ -95,8 +96,17 @@ public:
     }
 
     /**
+     * Compare ASN.1 types
+     * \param other Other ASN.1 type to compare with
+     * \return 0 if equal, <0 if other is "greater", >0 if other is "smaller"
+     */
+    int compare(const asn1c_wrapper_common& other) const
+    {
+        return vanetza::asn1::compare(m_type, m_struct, other.m_struct);
+    }
+
+    /**
      * Print ASN.1 type to standard output
-     * \param stream Output stream
      * \return 0 on success, -1 on error
      */
     int print() const 

--- a/vanetza/asn1/tests/asn1c_wrapper.cpp
+++ b/vanetza/asn1/tests/asn1c_wrapper.cpp
@@ -68,11 +68,10 @@ TEST(asn1c_wrapper, compare) {
     OCTET_STRING_fromString(&wrapper4->string, "1234");
 
     // .compare()
-    EXPECT_TRUE(!wrapper1.compare(wrapper1));
-    EXPECT_TRUE(!wrapper1.compare(wrapper2));
-    EXPECT_FALSE(!wrapper1.compare(wrapper3));
-    EXPECT_TRUE(wrapper1.compare(wrapper3) > 0);
-    EXPECT_FALSE(!wrapper1.compare(wrapper4));
+    EXPECT_EQ(wrapper1.compare(wrapper1), 0);
+    EXPECT_EQ(wrapper1.compare(wrapper2), 0);
+    EXPECT_EQ(wrapper1.compare(wrapper3), 1);
+    EXPECT_EQ(wrapper1.compare(wrapper4), -1);
 
     // operators == and !=
     EXPECT_TRUE(wrapper1 == wrapper1);

--- a/vanetza/asn1/tests/asn1c_wrapper.cpp
+++ b/vanetza/asn1/tests/asn1c_wrapper.cpp
@@ -56,6 +56,26 @@ TEST(asn1c_wrapper, validate) {
     EXPECT_FALSE(msg.empty());
 }
 
+TEST(asn1c_wrapper, compare) {
+    test_wrapper wrapper1(asn_DEF_VanetzaTest);
+    OCTET_STRING_fromString(&wrapper1->string, "1234");
+    EXPECT_TRUE(!wrapper1.compare(wrapper1));
+
+    test_wrapper wrapper2(asn_DEF_VanetzaTest);
+    OCTET_STRING_fromString(&wrapper2->string, "1234");
+    EXPECT_TRUE(!wrapper1.compare(wrapper2));
+
+    test_wrapper wrapper3(asn_DEF_VanetzaTest);
+    OCTET_STRING_fromString(&wrapper3->string, "0123");
+    EXPECT_FALSE(!wrapper1.compare(wrapper3));
+    EXPECT_TRUE(wrapper1.compare(wrapper3) > 0);
+
+    test_wrapper wrapper4(asn_DEF_VanetzaTest);
+    wrapper4->field = 5;
+    OCTET_STRING_fromString(&wrapper4->string, "1234");
+    EXPECT_FALSE(!wrapper1.compare(wrapper4));
+}
+
 TEST(asn1c_wrapper, print) {
     test_wrapper wrapper(asn_DEF_VanetzaTest);
     OCTET_STRING_fromString(&wrapper->string, "1234");

--- a/vanetza/asn1/tests/asn1c_wrapper.cpp
+++ b/vanetza/asn1/tests/asn1c_wrapper.cpp
@@ -59,21 +59,27 @@ TEST(asn1c_wrapper, validate) {
 TEST(asn1c_wrapper, compare) {
     test_wrapper wrapper1(asn_DEF_VanetzaTest);
     OCTET_STRING_fromString(&wrapper1->string, "1234");
-    EXPECT_TRUE(!wrapper1.compare(wrapper1));
-
     test_wrapper wrapper2(asn_DEF_VanetzaTest);
     OCTET_STRING_fromString(&wrapper2->string, "1234");
-    EXPECT_TRUE(!wrapper1.compare(wrapper2));
-
     test_wrapper wrapper3(asn_DEF_VanetzaTest);
     OCTET_STRING_fromString(&wrapper3->string, "0123");
-    EXPECT_FALSE(!wrapper1.compare(wrapper3));
-    EXPECT_TRUE(wrapper1.compare(wrapper3) > 0);
-
     test_wrapper wrapper4(asn_DEF_VanetzaTest);
     wrapper4->field = 5;
     OCTET_STRING_fromString(&wrapper4->string, "1234");
+
+    // .compare()
+    EXPECT_TRUE(!wrapper1.compare(wrapper1));
+    EXPECT_TRUE(!wrapper1.compare(wrapper2));
+    EXPECT_FALSE(!wrapper1.compare(wrapper3));
+    EXPECT_TRUE(wrapper1.compare(wrapper3) > 0);
     EXPECT_FALSE(!wrapper1.compare(wrapper4));
+
+    // operators == and !=
+    EXPECT_TRUE(wrapper1 == wrapper1);
+    EXPECT_TRUE(wrapper1 == wrapper2);
+    EXPECT_FALSE(wrapper1 == wrapper3);
+    EXPECT_TRUE(wrapper1 != wrapper3);
+    EXPECT_TRUE(wrapper1 != wrapper4);
 }
 
 TEST(asn1c_wrapper, print) {


### PR DESCRIPTION
Adds new `compare()` and related `==` and `!=` overloads to the asn1c wrapper.
Leverages asn1c's `compare_struct` operation, which tests the equality of two ASN.1 structs of the same type. 