### PR TITLE
asn1: OER-based copy for asn1c wrapper

### DIFF
--- a/vanetza/asn1/asn1c_wrapper.cpp
+++ b/vanetza/asn1/asn1c_wrapper.cpp
@@ -52,16 +52,16 @@ void* copy(asn_TYPE_descriptor_t& td, const void* original)
     ByteBuffer buffer;
 
     asn_enc_rval_t ec;
-    ec = der_encode(&td, const_cast<void*>(original), write_buffer, &buffer);
+    ec = oer_encode(&td, const_cast<void*>(original), write_buffer, &buffer);
     if (ec.encoded == -1) {
-        throw std::runtime_error("DER encoding failed");
+        throw std::runtime_error("OER encoding failed");
     }
 
     asn_dec_rval_t dc;
-    dc = ber_decode(0, &td, &copy, buffer.data(), buffer.size());
+    dc = oer_decode(0, &td, &copy, buffer.data(), buffer.size());
     if (dc.code != RC_OK) {
         free(td, copy);
-        throw std::runtime_error("BER decoding failed");
+        throw std::runtime_error("OER decoding failed");
     }
 
     return copy;


### PR DESCRIPTION
May I suggest the use of OER to do the roundtrip-based copy of ASN.1 types?
Unless there are any concerns with the implementation/safety of asn1c's OER, we can consider it over the current BER/DER copy since it is much faster.

A benchmark of 1000000 roundrip encoding/decodings of a zero-initialized CAM with some fields set to `1` to pass the constraint checks:
```
OER Roundtrip in 3.370587 s   // (canonical)
BER Roundtrip in 14.393260 s  // der -> ber
PER Roundtrip in 3.833098 s   // (canonical unaligned)
JER Roundtrip in 10.260315 s  // (minified)
XER Roundtrip in 14.103931 s  // (canonical)
```