### PR TITLE
Bug Fix: Catch further encoding exception when verifying message

### DIFF
--- a/vanetza/geonet/router.cpp
+++ b/vanetza/geonet/router.cpp
@@ -502,13 +502,14 @@ void Router::indicate_secured(IndicationContextBasic& ctx, const BasicHeader& ba
                 case DecapReport::False_Signature:
                 case DecapReport::Invalid_Certificate:
                 case DecapReport::Revoked_Certificate:
-                case DecapReport::Inconsistant_Chain:
+                case DecapReport::Inconsistent_Chain:
                 case DecapReport::Invalid_Timestamp:
                 case DecapReport::Invalid_Mobility_Data:
                 case DecapReport::Unsigned_Message:
                 case DecapReport::Signer_Certificate_Not_Found:
                 case DecapReport::Unsupported_Signer_Identifier_Type:
                 case DecapReport::Unencrypted_Message:
+                case DecapReport::None:
                     // ok, continue
                     boost::apply_visitor(visitor, decap_confirm.plaintext_payload);
                     break;

--- a/vanetza/security/decap_confirm.hpp
+++ b/vanetza/security/decap_confirm.hpp
@@ -15,24 +15,25 @@ namespace security
 
 /**
  * SN-DECAP.confirm report codes
- * \see TS 102 723-8 v1.1.1 table 27
+ * \see TS 102 723-8 v1.1.1 table 27 or AUTOSAR SWS_V2xM_91000
  */
 enum class DecapReport
 {
-    Success,
-    False_Signature,
-    Invalid_Certificate,
-    Revoked_Certificate,
-    Inconsistant_Chain,
-    Invalid_Timestamp,
-    Duplicate_Message,
-    Invalid_Mobility_Data,
-    Unsigned_Message,
-    Signer_Certificate_Not_Found,
-    Unsupported_Signer_Identifier_Type,
-    Incompatible_Protocol,
-    Unencrypted_Message,
-    Decryption_Error,
+    Success = 0x00,
+    False_Signature = 0x01,
+    Invalid_Certificate = 0x02,
+    Revoked_Certificate = 0x03,
+    Inconsistent_Chain = 0x04,
+    Invalid_Timestamp = 0x05,
+    Duplicate_Message = 0x06,
+    Invalid_Mobility_Data = 0x07,
+    Unsigned_Message = 0x08,
+    Signer_Certificate_Not_Found = 0x09,
+    Unsupported_Signer_Identifier_Type = 0x0a,
+    Incompatible_Protocol = 0x0b,
+    Unencrypted_Message = 0x0c,
+    Decryption_Error = 0x0d,
+    None = 0xff,
 };
 
 /** \brief contains output of the verify process

--- a/vanetza/security/straight_verify_service.cpp
+++ b/vanetza/security/straight_verify_service.cpp
@@ -431,6 +431,14 @@ VerifyConfirm StraightVerifyService::verify(const v3::SecuredMessage& msg)
         return confirm;
     }
 
+    ByteBuffer encoded_signing_payload;
+    try {
+        encoded_signing_payload = msg.signing_payload();
+    } catch (...) {
+        confirm.report = VerificationReport::False_Signature;
+        return confirm;
+    }
+
     ByteBuffer encoded_cert;
     try {
         encoded_cert = asn1::encode_oer(asn_DEF_CertificateBase, certificate);
@@ -439,7 +447,7 @@ VerifyConfirm StraightVerifyService::verify(const v3::SecuredMessage& msg)
         return confirm;
     }
 
-    ByteBuffer data_hash = m_backend.calculate_hash(public_key->type, msg.signing_payload());
+    ByteBuffer data_hash = m_backend.calculate_hash(public_key->type, encoded_signing_payload);
     ByteBuffer cert_hash = m_backend.calculate_hash(public_key->type, encoded_cert);
     ByteBuffer concat_hash = data_hash;
     concat_hash.insert(concat_hash.end(), cert_hash.begin(), cert_hash.end());

--- a/vanetza/security/straight_verify_service.cpp
+++ b/vanetza/security/straight_verify_service.cpp
@@ -435,7 +435,7 @@ VerifyConfirm StraightVerifyService::verify(const v3::SecuredMessage& msg)
     try {
         encoded_signing_payload = msg.signing_payload();
     } catch (...) {
-        confirm.report = VerificationReport::False_Signature;
+        confirm.report = VerificationReport::Decryption_Error;
         return confirm;
     }
 

--- a/vanetza/security/v3/certificate.cpp
+++ b/vanetza/security/v3/certificate.cpp
@@ -28,8 +28,12 @@ boost::optional<HashedId8> calculate_hash(const EtsiTs103097Certificate_t& cert)
     if (indicator.present != VerificationKeyIndicator_PR_verificationKey) {
         return boost::none;
     }
-
-    ByteBuffer buffer = asn1::encode_oer(asn_DEF_EtsiTs103097Certificate, &cert);
+    ByteBuffer buffer;
+    try {
+        buffer = asn1::encode_oer(asn_DEF_EtsiTs103097Certificate, &cert);
+    } catch (...) {
+        return boost::none;
+    }
     switch (indicator.choice.verificationKey.present)
     {
         case PublicVerificationKey_PR_ecdsaNistP256:

--- a/vanetza/security/verify_service.hpp
+++ b/vanetza/security/verify_service.hpp
@@ -16,19 +16,22 @@ namespace security
 
 enum class VerificationReport
 {
-    Success,
-    False_Signature,
-    Invalid_Certificate,
-    Revoked_Certificate,
-    Inconsistent_Chain,
-    Invalid_Timestamp,
-    Duplicate_Message,
-    Invalid_Mobility_Data,
-    Unsigned_Message,
-    Signer_Certificate_Not_Found,
-    Unsupported_Signer_Identifier_Type,
-    Incompatible_Protocol,
-    Configuration_Problem,
+    Success = 0x00,
+    False_Signature = 0x01,
+    Invalid_Certificate = 0x02,
+    Revoked_Certificate = 0x03,
+    Inconsistent_Chain = 0x04,
+    Invalid_Timestamp = 0x05,
+    Duplicate_Message = 0x06,
+    Invalid_Mobility_Data = 0x07,
+    Unsigned_Message = 0x08,
+    Signer_Certificate_Not_Found = 0x09,
+    Unsupported_Signer_Identifier_Type = 0x0a,
+    Incompatible_Protocol = 0x0b,
+    Unencrypted_Message = 0x0c,
+    Decryption_Error = 0x0d,
+    Configuration_Problem = 0x0e,
+    None = 0xff,
 };
 
 // mandatory parameters of SN-VERIFY.request (TS 102 723-8 V1.1.1)


### PR DESCRIPTION
When fuzzing with additional seeds, I noticed that `vanetza::security::v3::SecuredMessage::signing_payload` can throw an exception. For this reason, I assume that `vanetza::asn1::encode_oer` should never be called without proper exception handling. I have added further exception handlings in this pull request. 