### PR TITLE
Add InterfaceType LTE_V2X

### DIFF
--- a/vanetza/geonet/mib.hpp
+++ b/vanetza/geonet/mib.hpp
@@ -40,7 +40,8 @@ enum class AddrConfMethod {
 
 enum class InterfaceType {
     Unspecified = 0,
-    ITS_G5 = 1
+    ITS_G5 = 1,
+    LTE_V2X = 2
 };
 
 enum class SecurityDecapHandling {

--- a/vanetza/geonet/router.cpp
+++ b/vanetza/geonet/router.cpp
@@ -649,6 +649,7 @@ void Router::execute_media_procedures(CommunicationProfile com_profile)
             execute_itsg5_procedures();
             break;
         case CommunicationProfile::Unspecified:
+        case CommunicationProfile::LTE_V2X:
             // do nothing
             break;
         default:


### PR DESCRIPTION
ETSI EN 302 636-4-1 v1.4.1 has three itsGnIfType - Unspecified, its-g5 and lte-v2x.