### PR TITLE
Small fixes

### DIFF
--- a/vanetza/security/v2/sign_service.cpp
+++ b/vanetza/security/v2/sign_service.cpp
@@ -5,6 +5,7 @@
 #include <vanetza/security/v2/sign_header_policy.hpp>
 #include <vanetza/security/v2/sign_service.hpp>
 #include <vanetza/security/v2/signature.hpp>
+#include <future>
 
 namespace vanetza
 {

--- a/vanetza/security/v2/sign_service.cpp
+++ b/vanetza/security/v2/sign_service.cpp
@@ -5,7 +5,6 @@
 #include <vanetza/security/v2/sign_header_policy.hpp>
 #include <vanetza/security/v2/sign_service.hpp>
 #include <vanetza/security/v2/signature.hpp>
-#include <future>
 
 namespace vanetza
 {

--- a/vanetza/security/v2/signature.hpp
+++ b/vanetza/security/v2/signature.hpp
@@ -7,7 +7,6 @@
 #include <vanetza/security/v2/serialization.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/variant/variant.hpp>
-#include <future>
 
 namespace vanetza
 {

--- a/vanetza/security/v3/certificate.cpp
+++ b/vanetza/security/v3/certificate.cpp
@@ -622,7 +622,7 @@ Certificate fake_certificate()
     return certi;
 }
 
-void serialize(OutputArchive& ar, Certificate& certificate)
+void serialize(OutputArchive& ar, const Certificate& certificate)
 {
     ByteBuffer buffer = certificate.encode();
     ar.save_binary(buffer.data(), buffer.size());

--- a/vanetza/security/v3/certificate.hpp
+++ b/vanetza/security/v3/certificate.hpp
@@ -210,7 +210,7 @@ ByteBuffer get_app_permissions(const asn1::EtsiTs103097Certificate& cert, ItsAid
 
 void add_psid_group_permission(asn1::PsidGroupPermissions* group_permission, ItsAid aid, const ByteBuffer& ssp, const ByteBuffer& bitmask);
 
-void serialize(OutputArchive& ar, Certificate& certificate);
+void serialize(OutputArchive& ar, const Certificate& certificate);
 
 Certificate fake_certificate();
 

--- a/vanetza/security/v3/persistence.cpp
+++ b/vanetza/security/v3/persistence.cpp
@@ -103,7 +103,7 @@ Certificate load_certificate_from_file(const std::string& certificate_path)
     return certificate;
 }
 
-void save_certificate_to_file(const std::string& certificate_path, Certificate& certificate)
+void save_certificate_to_file(const std::string& certificate_path, const Certificate& certificate)
 {
     std::ofstream dest;
     dest.open(certificate_path.c_str(), std::ios::out | std::ios::binary);

--- a/vanetza/security/v3/persistence.hpp
+++ b/vanetza/security/v3/persistence.hpp
@@ -45,7 +45,7 @@ Certificate load_certificate_from_file(const std::string& certificate_path);
  */
 void save_certificate_to_file(const std::string& certificate_path, const Certificate& certificate);
 
-} // namespace v2
+} // namespace v3
 } // namespace security
 } // namespace vanetza
 


### PR DESCRIPTION
Hi,
couple of small changes:
1. Pretty sure by this - `vanetza::security::v3::save_certificate_to_file()` has `certificate` parameter `const` in header but not `const` in implementation. Adding it there requires that `vanetza::security::v3::serialize()` for certificate has this parameter also `const`. Further, small comment fix.
2. Small cleanup - remove `<future>` header inclusion from `vanetza/security/v2/sign_service.cpp` and `vanetza/security/v2/signature.hpp` as it seems not needed here, just in `vanetza/security/signature.hpp`. This was just for my convenience when building library for C++/CLI wrapper, since that does not support `<future>` and I wanted it in as few places as possible. Please ignore this if you think it is not needed.