### PR TITLE
Removing Autotalks find operation in Root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ endforeach()
 include(CompatBoostTargets)
 find_package(CryptoPP 5.6.1 REQUIRED)
 find_package(GeographicLib 1.37 REQUIRED)
-find_package(Autotalks MODULE QUIET)
 
 if(Boost_VERSION_STRING STRGREATER_EQUAL 1.80)
   set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
Since the Autotalks library is used for only **socktap** tool and is optional, the find operation should be removed from the root `CMakeLists.txt`. I think, it is actually the same case with Cohda libraries' find operation.