### PR TITLE
security: add hmac, v3/basic_elements, v3/trust_store, v3/validity_restriction

### DIFF
--- a/vanetza/security/CMakeLists.txt
+++ b/vanetza/security/CMakeLists.txt
@@ -8,6 +8,7 @@ add_vanetza_component(security
     ecdsa256.cpp
     encap_service.cpp
     hashed_id.cpp
+    hmac.cpp
     key_type.cpp
     peer_request_tracker.cpp
     secured_message.cpp
@@ -46,6 +47,7 @@ add_vanetza_component(security
     v2/validity_restriction.cpp
     v2/verification.cpp
     v3/asn1_conversions.cpp
+    v3/basic_elements.cpp
     v3/certificate.cpp
     v3/certificate_cache.cpp
     v3/certificate_validator.cpp
@@ -57,6 +59,8 @@ add_vanetza_component(security
     v3/sign_header_policy.cpp
     v3/static_certificate_provider.cpp
     v3/persistence.cpp
+    v3/trust_store.cpp
+    v3/validity_restriction.cpp
 )
 target_link_libraries(security PUBLIC asn1 asn1_security common net)
 target_link_libraries(security PRIVATE GeographicLib::GeographicLib)

--- a/vanetza/security/hmac.cpp
+++ b/vanetza/security/hmac.cpp
@@ -1,0 +1,27 @@
+#include <vanetza/security/hmac.hpp>
+#include <cryptopp/osrng.h>
+#include <cryptopp/hmac.h>
+#include <cryptopp/sha.h>
+
+namespace vanetza
+{
+namespace security
+{
+
+KeyTag create_hmac_tag(const ByteBuffer& data, const HmacKey& hmacKey)
+{
+    KeyTag keyTag;
+
+    // Calculate tag.
+    CryptoPP::HMAC<CryptoPP::SHA256> mac(hmacKey.data(), hmacKey.size());
+    unsigned char tag[hmacKey.size()];
+    mac.Update(data.data(), data.size());
+    mac.Final(tag);
+
+    // Tag is truncated to leftmost 128 bits.
+    std::copy_n(tag, keyTag.size(), keyTag.data());
+    return keyTag;
+}
+
+} // namespace security
+} // namespace vanetza

--- a/vanetza/security/hmac.hpp
+++ b/vanetza/security/hmac.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <vanetza/common/byte_buffer.hpp>
+#include <array>
+#include <cstdint>
+
+namespace vanetza
+{
+namespace security
+{
+
+using HmacKey = std::array<uint8_t, 32>;
+using KeyTag = std::array<uint8_t, 16>;
+
+/**
+ * \brief generate HMAC key and create HMAC tag on data
+ * \param data data to be tagged
+ * \param hmacKey generated HMAC key
+ * \return tag of data generated with hmacKey
+*/
+KeyTag create_hmac_tag(const vanetza::ByteBuffer& data, const HmacKey& hmacKey);
+
+} // namespace security
+} // namespace vanetza

--- a/vanetza/security/v3/basic_elements.cpp
+++ b/vanetza/security/v3/basic_elements.cpp
@@ -1,0 +1,46 @@
+#include <vanetza/security/v3/basic_elements.hpp>
+#include <vanetza/asn1/support/OCTET_STRING.h>
+#include <vanetza/common/byte_buffer.hpp>
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+
+namespace vanetza
+{
+namespace security
+{
+namespace v3
+{
+
+Time32 convert_time32(const Clock::time_point& tp)
+{
+    using std::chrono::duration_cast;
+    using seconds = std::chrono::duration<Time32>;
+    return duration_cast<seconds>(tp.time_since_epoch()).count();
+}
+
+Clock::time_point convert_time_point(const Time32& t)
+{
+    using std::chrono::duration_cast;
+    using seconds = std::chrono::duration<Time32>;
+    return Clock::time_point { duration_cast<Clock::duration>(seconds(t)) };
+}
+
+Clock::time_point convert_time_point(const Time64& t)
+{
+    using std::chrono::duration_cast;
+    using microseconds = std::chrono::duration<Time64, std::micro>;
+    return Clock::time_point { duration_cast<Clock::duration>(microseconds(t)) };
+}
+
+Time64 convert_time64(const Clock::time_point& tp)
+{
+    using std::chrono::duration_cast;
+    using microseconds = std::chrono::duration<Time64, std::micro>;
+    return duration_cast<microseconds>(tp.time_since_epoch()).count();
+}
+
+
+} // namespace v3
+} // namespace security
+} // namespace vanetza

--- a/vanetza/security/v3/basic_elements.hpp
+++ b/vanetza/security/v3/basic_elements.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include <vanetza/common/clock.hpp>
+#include <vanetza/asn1/support/OCTET_STRING.h>
+#include <vanetza/common/byte_buffer.hpp>
+#include <array>
+#include <cstdint>
+
+namespace vanetza
+{
+namespace security
+{
+namespace v3
+{
+
+using Time64 = uint64_t;
+using Time32 = uint32_t;
+
+/**
+ * Convert time point to time stamp
+ * \param tp time point
+ * \return time stamp with second accuracy
+ */
+Time32 convert_time32(const Clock::time_point& tp);
+
+/**
+ * Convert time stamp to time point
+ * \param t time stamp with second accuracy
+ * \return time point
+ */
+Clock::time_point convert_time_point(const Time32& t);
+
+/**
+ * Convert time point to time stamp
+ * \param tp time point
+ * \return time stamp with microsecond accuracy
+ */
+Time64 convert_time64(const Clock::time_point& tp);
+
+/**
+ * Convert time stamp to time point
+ * \param t time stamp with microsecond accuracy
+ * \return time point
+ */
+Clock::time_point convert_time_point(const Time64& t);
+
+} // namespace v3
+} // namespace security
+} // namespace vanetza

--- a/vanetza/security/v3/certificate.hpp
+++ b/vanetza/security/v3/certificate.hpp
@@ -10,7 +10,9 @@
 #include <vanetza/security/public_key.hpp>
 #include <vanetza/security/signature.hpp>
 #include <vanetza/security/v3/asn1_types.hpp>
+#include <vanetza/security/v3/validity_restriction.hpp>
 #include <boost/optional/optional_fwd.hpp>
+#include <list>
 
 namespace vanetza
 {
@@ -40,6 +42,12 @@ public:
     boost::optional<HashedId8> calculate_digest() const;
 
     /**
+     * Get start and end validity
+     * \return certificate start and end validity
+     */
+    StartAndEndValidity get_start_and_end_validity() const;
+
+    /**
      * Get verification key type
      * \return verification key type if possible; otherwise unspecified
      */
@@ -50,6 +58,12 @@ public:
      * \return issuer digest
      */
     boost::optional<HashedId8> issuer_digest() const;
+
+    /**
+     * Check if certificate is self-signed
+     * \return true if certificate is self-signed
+     */
+    bool issuer_is_self() const;
 
     /**
      * Check if certificate is a Certification Authority certificate
@@ -199,6 +213,27 @@ boost::optional<PublicKey> get_public_key(const asn1::EtsiTs103097Certificate& c
  * \return verification key type (maybe unspecified)
  */
 KeyType get_verification_key_type(const asn1::EtsiTs103097Certificate& cert);
+
+/**
+ * Extract the public key for encrypting out of a certificate
+ * \param cert certificate
+ * \return encryption key if possible
+ */
+boost::optional<PublicKey> get_public_encryption_key(const asn1::EtsiTs103097Certificate& cert);
+
+/**
+ * Extract the signature out of a certificate
+ * \param cert certificate
+ * \return signature if possible
+ */
+boost::optional<Signature> get_signature(const asn1::EtsiTs103097Certificate& cert);
+
+/**
+ * Get list of ITS AID permissions from certificate
+ * \param cert certificate
+ * \return list of ITS AIDs
+ */
+std::list<ItsAid> get_aids(const asn1::EtsiTs103097Certificate& cert);
 
 /**
  * Get application permissions (SSP = service specific permissions)

--- a/vanetza/security/v3/trust_store.cpp
+++ b/vanetza/security/v3/trust_store.cpp
@@ -1,0 +1,39 @@
+#include <vanetza/security/v3/trust_store.hpp>
+#include <boost/optional.hpp>
+#include <stdexcept>
+
+namespace vanetza
+{
+namespace security
+{
+namespace v3
+{
+
+void TrustStore::insert(const Certificate& certificate)
+{
+    if (!certificate.issuer_is_self()) {
+        throw std::runtime_error("Only root certificate authorities may be added to the trust store");
+    }
+
+    auto id = certificate.calculate_digest();
+    if (!id) {
+        throw std::runtime_error("Cannot calculate hash for certificate");
+    }
+    m_certificates.insert(std::make_pair(*id, certificate));
+}
+
+std::list<Certificate> TrustStore::lookup(HashedId8 id) const
+{
+    using iterator = std::multimap<HashedId8, Certificate>::const_iterator;
+    std::pair<iterator, iterator> range = m_certificates.equal_range(id);
+
+    std::list<Certificate> matches;
+    for (auto item = range.first; item != range.second; ++item) {
+        matches.push_back(item->second);
+    }
+    return matches;
+}
+
+} // namespace v3
+} // namespace security
+} // namespace vanetza

--- a/vanetza/security/v3/trust_store.hpp
+++ b/vanetza/security/v3/trust_store.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include <vanetza/security/hashed_id.hpp>
+#include <vanetza/security/v3/certificate.hpp>
+#include <list>
+#include <map>
+
+namespace vanetza
+{
+namespace security
+{
+namespace v3
+{
+
+class TrustStore
+{
+public:
+    /**
+     * Lookup certificates based on the passed HashedId8.
+     *
+     * \param id hash identifier of the certificate
+     * \return all stored certificates matching the passed identifier
+     */
+    std::list<Certificate> lookup(HashedId8 id) const;
+
+    /**
+     * Insert a certificate into store, i.e. consider it as trustworthy.
+     * \param trusted_certificate a trustworthy certificate copied into TrustStore
+     */
+    void insert(const Certificate& trusted_certificate);
+
+protected:
+    std::multimap<HashedId8, Certificate> m_certificates;
+};
+
+} // namespace v3
+} // namespace security
+} // namespace vanetza

--- a/vanetza/security/v3/validity_restriction.cpp
+++ b/vanetza/security/v3/validity_restriction.cpp
@@ -1,0 +1,18 @@
+#include <vanetza/security/v3/validity_restriction.hpp>
+
+
+namespace vanetza
+{
+namespace security
+{
+namespace v3
+{
+
+StartAndEndValidity::StartAndEndValidity(Time32 start, Time32 end) :
+    start_validity(start), end_validity(end)
+{
+}
+
+} // namespace v3
+} // namespace security
+} // namespace vanetza

--- a/vanetza/security/v3/validity_restriction.hpp
+++ b/vanetza/security/v3/validity_restriction.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <cstdint>
+
+namespace vanetza
+{
+namespace security
+{
+namespace v3
+{
+
+using Time32 = std::uint32_t;
+
+struct StartAndEndValidity
+{
+    StartAndEndValidity() = default;
+    StartAndEndValidity(Time32 start, Time32 end);
+
+    Time32 start_validity;
+    Time32 end_validity;
+};
+
+} // namespace v3
+} // namespace security
+} // namespace vanetza


### PR DESCRIPTION
Add v3/ files and HMAC implementation.
Some helpers methods for V3 certificate must be added too or else the build fails.