### PR TITLE
correct invalid warning directive in hmac.cpp

### DIFF
--- a/vanetza/security/hmac.cpp
+++ b/vanetza/security/hmac.cpp
@@ -49,7 +49,7 @@ KeyTag create_hmac_tag(const ByteBuffer& data, const HmacKey& hmacKey)
 #elif defined VANETZA_WITH_CRYPTOPP
     return create_hmac_tag_cryptopp(data, hmacKey);
 #else
-#   warn "no HMAC implementation available"
+#   warning "no HMAC implementation available"
     return KeyTag {};
 #endif
 }


### PR DESCRIPTION
probably no-one hit that edge-case before. but "warn" is not valid and thus leads the build to an fail and not a warning