### PR TITLE
pki/certify: print subject keys and HTTP error details

### DIFF
--- a/tools/certify/commands/show-certificate.cpp
+++ b/tools/certify/commands/show-certificate.cpp
@@ -8,11 +8,61 @@
 #include <vanetza/common/its_aid.hpp>
 #include <vanetza/security/cam_ssp.hpp>
 #include <vanetza/security/v2/certificate.hpp>
+#include <vanetza/security/v2/ecc_point.hpp>
 #include <vanetza/security/v2/persistence.hpp>
+#include <vanetza/security/v2/public_key.hpp>
 
 namespace po = boost::program_options;
 using namespace vanetza;
 using namespace vanetza::security;
+
+namespace {
+
+std::string hex_buffer(const ByteBuffer& buffer)
+{
+    std::string bytes(buffer.begin(), buffer.end());
+    return boost::algorithm::hex(bytes);
+}
+
+void print_ecc_point(const EccPoint& point, const std::string& indent)
+{
+    switch (v2::get_type(point)) {
+        case v2::EccPointType::X_Coordinate_Only:
+            std::cout << indent << "X: " << hex_buffer(boost::get<X_Coordinate_Only>(point).x)
+                      << " (x-coordinate only)" << std::endl;
+            break;
+        case v2::EccPointType::Compressed_Lsb_Y_0:
+            std::cout << indent << "X: " << hex_buffer(boost::get<Compressed_Lsb_Y_0>(point).x)
+                      << " (compressed, y LSB 0)" << std::endl;
+            break;
+        case v2::EccPointType::Compressed_Lsb_Y_1:
+            std::cout << indent << "X: " << hex_buffer(boost::get<Compressed_Lsb_Y_1>(point).x)
+                      << " (compressed, y LSB 1)" << std::endl;
+            break;
+        case v2::EccPointType::Uncompressed: {
+            const Uncompressed& uncompressed = boost::get<Uncompressed>(point);
+            std::cout << indent << "X: " << hex_buffer(uncompressed.x) << std::endl;
+            std::cout << indent << "Y: " << hex_buffer(uncompressed.y) << " (uncompressed)" << std::endl;
+            break;
+        }
+    }
+}
+
+void print_public_key(const v2::PublicKey& key, const std::string& indent)
+{
+    switch (v2::get_type(key)) {
+        case v2::PublicKeyAlgorithm::ECDSA_NISTP256_With_SHA256:
+            std::cout << indent << "Algorithm: ECDSA NISTP256 with SHA-256" << std::endl;
+            print_ecc_point(boost::get<v2::ecdsa_nistp256_with_sha256>(key).public_key, indent);
+            break;
+        case v2::PublicKeyAlgorithm::ECIES_NISTP256:
+            std::cout << indent << "Algorithm: ECIES NISTP256" << std::endl;
+            print_ecc_point(boost::get<v2::ecies_nistp256>(key).public_key, indent);
+            break;
+    }
+}
+
+} // namespace
 
 bool ShowCertificateCommand::parse(const std::vector<std::string>& opts)
 {
@@ -102,13 +152,23 @@ int ShowCertificateCommand::execute()
 
     std::cout << std::endl;
 
-    // TODO Support Verification_Key, Encryption_Key, Reconstruction_Value
-
     unsigned certificate_application_ids = 0;
 
     for (auto& subject_attr : cert.subject_attributes) {
         v2::SubjectAttributeType attr_type = get_type(subject_attr);
-        if (attr_type == v2::SubjectAttributeType::Assurance_Level) {
+        if (attr_type == v2::SubjectAttributeType::Verification_Key) {
+            std::cout << "Verification Key:" << std::endl;
+            print_public_key(boost::get<v2::VerificationKey>(subject_attr).key, " - ");
+            std::cout << std::endl;
+        } else if (attr_type == v2::SubjectAttributeType::Encryption_Key) {
+            std::cout << "Encryption Key:" << std::endl;
+            print_public_key(boost::get<v2::EncryptionKey>(subject_attr).key, " - ");
+            std::cout << std::endl;
+        } else if (attr_type == v2::SubjectAttributeType::Reconstruction_Value) {
+            std::cout << "Reconstruction Value:" << std::endl;
+            print_ecc_point(boost::get<EccPoint>(subject_attr), " - ");
+            std::cout << std::endl;
+        } else if (attr_type == v2::SubjectAttributeType::Assurance_Level) {
             v2::SubjectAssurance assurance = boost::get<v2::SubjectAssurance>(subject_attr);
             std::cout << "Assurance: " << (assurance.raw & assurance.assurance_mask);
             std::cout << " with a confidence of " <<  (assurance.raw & assurance.confidence_mask);

--- a/tools/pki/authorization.cpp
+++ b/tools/pki/authorization.cpp
@@ -263,10 +263,8 @@ void request_one_ticket(Context& ctx, const Certificate& ec, const AuthoritiesFr
     auto response = http_post(query, "application/x-its-request", encoded);
 
     if (response.result() != boost::beast::http::status::ok) {
-        const auto& body = response.body();
-        std::string body_str(reinterpret_cast<const char*>(body.data()), body.size());
-        throw HttpException("AA returned an unexpected HTTP status for the authorization request: "
-            + std::to_string(response.result_int()) + " (" + body_str + ")");
+        throw HttpException("AA returned an unexpected HTTP status for the authorization request",
+            std::move(response));
     } else if (response[boost::beast::http::field::content_type] != "application/x-its-response") {
         throw HttpException("expected application/x-its-response");
     }

--- a/tools/pki/authorization.cpp
+++ b/tools/pki/authorization.cpp
@@ -263,7 +263,10 @@ void request_one_ticket(Context& ctx, const Certificate& ec, const AuthoritiesFr
     auto response = http_post(query, "application/x-its-request", encoded);
 
     if (response.result() != boost::beast::http::status::ok) {
-        throw HttpException("AA returned an unexpected HTTP status for the authorization request");
+        const auto& body = response.body();
+        std::string body_str(reinterpret_cast<const char*>(body.data()), body.size());
+        throw HttpException("AA returned an unexpected HTTP status for the authorization request: "
+            + std::to_string(response.result_int()) + " (" + body_str + ")");
     } else if (response[boost::beast::http::field::content_type] != "application/x-its-response") {
         throw HttpException("expected application/x-its-response");
     }

--- a/tools/pki/cpoc.cpp
+++ b/tools/pki/cpoc.cpp
@@ -45,7 +45,10 @@ Certificate fetch_tlm_certificate(const std::string& base_url, const HashedId8* 
     auto query = HttpQuery::from_url(base_url + "/gettlmcertificate/" + (id ? hexstring(*id) : ""));
     auto response = http_get(query);
     if (response.result() != boost::beast::http::status::ok) {
-        throw HttpException("CPOC returned an unexpected HTTP status when fetching TLM certificate");
+        const auto& body = response.body();
+        std::string body_str(reinterpret_cast<const char*>(body.data()), body.size());
+        throw HttpException("CPOC returned an unexpected HTTP status when fetching TLM certificate: "
+            + std::to_string(response.result_int()) + " (" + body_str + ")");
     } else if (response[boost::beast::http::field::content_type] != "application/octet-stream") {
         throw HttpException("did not receive bytes from CPOC when fetching TLM certificate");
     } else {
@@ -211,7 +214,10 @@ void fetch_ectl(Context& context, const HashedId8* tlm_id, bool dry_run)
     auto query = HttpQuery::from_url(context.cpoc_url + "/getectl/" + hexstring(tlm_hid8));
     auto response = http_get(query);
     if (response.result() != boost::beast::http::status::ok) {
-        throw HttpException("CPOC returned an unexpected HTTP status when fetching full ECTL");
+        const auto& body = response.body();
+        std::string body_str(reinterpret_cast<const char*>(body.data()), body.size());
+        throw HttpException("CPOC returned an unexpected HTTP status when fetching full ECTL: "
+            + std::to_string(response.result_int()) + " (" + body_str + ")");
     } else if (response[boost::beast::http::field::content_type] != "application/octet-stream") {
         throw HttpException("did not receive bytes from CPOC when fetching full ECTL");
     }

--- a/tools/pki/cpoc.cpp
+++ b/tools/pki/cpoc.cpp
@@ -45,10 +45,8 @@ Certificate fetch_tlm_certificate(const std::string& base_url, const HashedId8* 
     auto query = HttpQuery::from_url(base_url + "/gettlmcertificate/" + (id ? hexstring(*id) : ""));
     auto response = http_get(query);
     if (response.result() != boost::beast::http::status::ok) {
-        const auto& body = response.body();
-        std::string body_str(reinterpret_cast<const char*>(body.data()), body.size());
-        throw HttpException("CPOC returned an unexpected HTTP status when fetching TLM certificate: "
-            + std::to_string(response.result_int()) + " (" + body_str + ")");
+        throw HttpException("CPOC returned an unexpected HTTP status when fetching TLM certificate",
+            std::move(response));
     } else if (response[boost::beast::http::field::content_type] != "application/octet-stream") {
         throw HttpException("did not receive bytes from CPOC when fetching TLM certificate");
     } else {
@@ -214,10 +212,8 @@ void fetch_ectl(Context& context, const HashedId8* tlm_id, bool dry_run)
     auto query = HttpQuery::from_url(context.cpoc_url + "/getectl/" + hexstring(tlm_hid8));
     auto response = http_get(query);
     if (response.result() != boost::beast::http::status::ok) {
-        const auto& body = response.body();
-        std::string body_str(reinterpret_cast<const char*>(body.data()), body.size());
-        throw HttpException("CPOC returned an unexpected HTTP status when fetching full ECTL: "
-            + std::to_string(response.result_int()) + " (" + body_str + ")");
+        throw HttpException("CPOC returned an unexpected HTTP status when fetching full ECTL",
+            std::move(response));
     } else if (response[boost::beast::http::field::content_type] != "application/octet-stream") {
         throw HttpException("did not receive bytes from CPOC when fetching full ECTL");
     }

--- a/tools/pki/enrolment.cpp
+++ b/tools/pki/enrolment.cpp
@@ -215,7 +215,10 @@ void perform_enrolment(Context& ctx, const EnrolmentRequestParameters& params, c
 
     auto response = http_post(query, "application/x-its-request", encoded_encrypted_data);
     if (response.result() != boost::beast::http::status::ok) {
-        throw HttpException("EA returned an unexpected HTTP status for the enrolment request");
+        const auto& body = response.body();
+        std::string body_str(reinterpret_cast<const char*>(body.data()), body.size());
+        throw HttpException("EA returned an unexpected HTTP status for the enrolment request: "
+            + std::to_string(response.result_int()) + " (" + body_str + ")");
     } else if (response[boost::beast::http::field::content_type] != "application/x-its-response") {
         throw HttpException("expected application/x-its-response");
     }

--- a/tools/pki/enrolment.cpp
+++ b/tools/pki/enrolment.cpp
@@ -215,10 +215,8 @@ void perform_enrolment(Context& ctx, const EnrolmentRequestParameters& params, c
 
     auto response = http_post(query, "application/x-its-request", encoded_encrypted_data);
     if (response.result() != boost::beast::http::status::ok) {
-        const auto& body = response.body();
-        std::string body_str(reinterpret_cast<const char*>(body.data()), body.size());
-        throw HttpException("EA returned an unexpected HTTP status for the enrolment request: "
-            + std::to_string(response.result_int()) + " (" + body_str + ")");
+        throw HttpException("EA returned an unexpected HTTP status for the enrolment request",
+            std::move(response));
     } else if (response[boost::beast::http::field::content_type] != "application/x-its-response") {
         throw HttpException("expected application/x-its-response");
     }

--- a/tools/pki/http.cpp
+++ b/tools/pki/http.cpp
@@ -6,6 +6,7 @@
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/ssl.hpp>
+#include <ostream>
 #include <regex>
 
 namespace vanetza
@@ -16,6 +17,19 @@ namespace pki
 namespace asio = boost::asio;
 namespace beast = boost::beast;
 namespace ssl = boost::asio::ssl;
+
+std::ostream& operator<<(std::ostream& os, const HttpException& e)
+{
+    os << e.what();
+    if (const auto& response = e.response()) {
+        os << " (HTTP " << response->result_int();
+        if (!response->body().empty()) {
+            os << ": " << response->body();
+        }
+        os << ")";
+    }
+    return os;
+}
 
 HttpQuery HttpQuery::from_url(const std::string& url)
 {

--- a/tools/pki/http.hpp
+++ b/tools/pki/http.hpp
@@ -2,8 +2,11 @@
 
 #include <vanetza/common/byte_buffer.hpp>
 #include <boost/beast/http.hpp>
+#include <boost/optional/optional.hpp>
+#include <iosfwd>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace vanetza
 {
@@ -15,7 +18,20 @@ using HttpResponse = boost::beast::http::response<boost::beast::http::string_bod
 struct HttpException : public std::runtime_error
 {
     using std::runtime_error::runtime_error;
+
+    HttpException(const std::string& what, HttpResponse response) :
+        std::runtime_error(what), m_response(std::move(response))
+    {
+    }
+
+    // Server response associated with the failure, if any.
+    const boost::optional<HttpResponse>& response() const { return m_response; }
+
+private:
+    boost::optional<HttpResponse> m_response;
 };
+
+std::ostream& operator<<(std::ostream& os, const HttpException& e);
 
 struct HttpQuery
 {

--- a/tools/pki/main.cpp
+++ b/tools/pki/main.cpp
@@ -6,6 +6,7 @@
 #include "dc_command.hpp"
 #include "enrolment.hpp"
 #include "exception.hpp"
+#include "http.hpp"
 #include "openssl_security_module.hpp"
 #include "printing.hpp"
 #include "prune_command.hpp"
@@ -95,6 +96,9 @@ int main(int argc, char** argv)
         return 3;
     } catch (const DecodingFailure& e) {
         std::cerr << "Decoding failed: " << e.what() << "\n";
+        return 1;
+    } catch (const HttpException& e) {
+        std::cerr << "HTTP error: " << e << "\n";
         return 1;
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << "\n";


### PR DESCRIPTION
TODO done:
- **certify** - show-certificate: decode and print the `Verification_Key`, `Encryption_Key` and `Reconstruction_Value` subject attributes.

Diagnostics:
- **pki**: include the HTTP status and response body in EA/AA/CPOC error messages.