### PR TITLE
security: check v3 certificate chain consistency

### DIFF
--- a/vanetza/security/v3/certificate.cpp
+++ b/vanetza/security/v3/certificate.cpp
@@ -3,6 +3,7 @@
 #include <vanetza/security/v3/asn1_conversions.hpp>
 #include <vanetza/security/v3/certificate.hpp>
 #include <vanetza/security/v3/distance.hpp>
+#include <vanetza/security/v3/geometry.hpp>
 #include <boost/optional/optional.hpp>
 #include <cassert>
 #include <cstdlib>
@@ -28,6 +29,14 @@ bool is_compressed(const Vanetza_Security_EccP384CurvePoint& point);
 bool is_signature_x_only(const Vanetza_Security_Signature_t& sig);
 bool compress(Vanetza_Security_EccP256CurvePoint&);
 bool compress(Vanetza_Security_EccP384CurvePoint&);
+bool contains_permission(const Vanetza_Security_SequenceOfPsidSspRange_t& permissions, ItsAid aid);
+bool equal(const asn1::TwoDLocation& lhs, const asn1::TwoDLocation& rhs);
+bool equal(const asn1::RectangularRegion& lhs, const asn1::RectangularRegion& rhs);
+bool equal(const asn1::SequenceOfRectangularRegion& lhs, const asn1::SequenceOfRectangularRegion& rhs);
+bool is_within(const asn1::GeographicRegion& inner, const asn1::CircularRegion& outer);
+bool is_within(const asn1::GeographicRegion& inner, const asn1::SequenceOfRectangularRegion& outer);
+bool is_within(const asn1::GeographicRegion& inner, const asn1::PolygonalRegion& outer);
+bool is_within(const asn1::GeographicRegion& inner, const asn1::GeographicRegion& outer);
 bool make_x_only(Vanetza_Security_EccP256CurvePoint&);
 bool make_x_only(Vanetza_Security_EccP384CurvePoint&);
 bool make_signature_x_only(Vanetza_Security_Signature_t& sig);
@@ -142,6 +151,59 @@ bool valid_at_timepoint(const asn1::EtsiTs103097Certificate& cert, const Clock::
 bool CertificateView::valid_for_application(ItsAid aid) const
 {
     return m_cert ? v3::valid_for_application(*m_cert, aid) : false;
+}
+
+bool CertificateView::is_allowed_to_issue(ItsAid aid) const
+{
+    if (!m_cert) {
+        return false;
+    }
+
+    if (const auto* seq = m_cert->toBeSigned.certIssuePermissions; seq) {
+        for (int i = 0; i < seq->list.count; ++i) {
+            const auto* group = seq->list.array[i];
+            if (!group) {
+                continue;
+            }
+
+            const auto& subject_permissions = group->subjectPermissions;
+            if (subject_permissions.present == Vanetza_Security_SubjectPermissions_PR_all) {
+                return true;
+            } else if (
+                    subject_permissions.present == Vanetza_Security_SubjectPermissions_PR_explicit &&
+                    contains_permission(subject_permissions.choice.Explicit, aid)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+boost::optional<std::uint8_t> CertificateView::assurance_level() const
+{
+    if (!m_cert || !m_cert->toBeSigned.assuranceLevel || m_cert->toBeSigned.assuranceLevel->size == 0) {
+        return boost::none;
+    }
+
+    return m_cert->toBeSigned.assuranceLevel->buf[0];
+}
+
+bool CertificateView::region_is_within(const CertificateView& issuer) const
+{
+    if (!m_cert || !issuer.m_cert) {
+        return false;
+    }
+
+    const auto* issuer_region = issuer.m_cert->toBeSigned.region;
+    const auto* subject_region = m_cert->toBeSigned.region;
+    if (!issuer_region) {
+        return true;
+    } else if (!subject_region) {
+        return false;
+    } else {
+        return is_within(*subject_region, *issuer_region);
+    }
 }
 
 bool valid_for_application(const asn1::EtsiTs103097Certificate& cert, ItsAid aid)
@@ -275,11 +337,6 @@ bool is_canonical(const asn1::EtsiTs103097Certificate& cert)
 ByteBuffer CertificateView::encode() const
 {
     return m_cert ? asn1::encode_oer(asn_DEF_Vanetza_Security_EtsiTs103097Certificate, m_cert) : ByteBuffer {};
-}
-
-const asn1::EtsiTs103097Certificate* CertificateView::raw_certificate() const
-{
-    return m_cert;
 }
 
 ByteBuffer Certificate::encode() const
@@ -533,36 +590,6 @@ std::list<ItsAid> get_aids(const asn1::EtsiTs103097Certificate& cert)
     return aids;
 }
 
-std::list<ItsAid> get_issuer_aids(const asn1::EtsiTs103097Certificate& cert)
-{
-    std::list<ItsAid> aids;
-    const asn1::SequenceOfPsidGroupPermissions* seq = cert.toBeSigned.certIssuePermissions;
-    if (seq) {
-        for (int i = 0; i < seq->list.count; ++i) {
-            const auto* group = seq->list.array[i];
-            if (!group) {
-                continue;
-            }
-            switch (group->subjectPermissions.present) {
-                case Vanetza_Security_SubjectPermissions_PR_explicit: {
-                    const auto& explicit_perms = group->subjectPermissions.choice.Explicit;
-                    for (int j = 0; j < explicit_perms.list.count; ++j) {
-                        if (explicit_perms.list.array[j]) {
-                            aids.push_back(explicit_perms.list.array[j]->psid);
-                        }
-                    }
-                    break;
-                }
-                case Vanetza_Security_SubjectPermissions_PR_all:
-                    return {};
-                default:
-                    break;
-            }
-        }
-    }
-    return aids;
-}
-
 ByteBuffer get_app_permissions(const asn1::EtsiTs103097Certificate& cert, ItsAid aid)
 {
     ByteBuffer perms;
@@ -701,6 +728,87 @@ void serialize(OutputArchive& ar, const Certificate& certificate)
 
 namespace
 {
+
+bool contains_permission(const Vanetza_Security_SequenceOfPsidSspRange_t& permissions, ItsAid aid)
+{
+    for (int i = 0; i < permissions.list.count; ++i) {
+        const auto* permission = permissions.list.array[i];
+        if (permission && permission->psid == aid) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool equal(const asn1::TwoDLocation& lhs, const asn1::TwoDLocation& rhs)
+{
+    return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude;
+}
+
+bool equal(const asn1::RectangularRegion& lhs, const asn1::RectangularRegion& rhs)
+{
+    return equal(lhs.northWest, rhs.northWest) && equal(lhs.southEast, rhs.southEast);
+}
+
+bool equal(const asn1::SequenceOfRectangularRegion& lhs, const asn1::SequenceOfRectangularRegion& rhs)
+{
+    if (lhs.list.count != rhs.list.count) {
+        return false;
+    }
+
+    for (int i = 0; i < lhs.list.count; ++i) {
+        if (!lhs.list.array[i] || !rhs.list.array[i] || !equal(*lhs.list.array[i], *rhs.list.array[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool is_within(const asn1::GeographicRegion& inner, const asn1::CircularRegion& outer)
+{
+    if (inner.present != Vanetza_Security_GeographicRegion_PR_circularRegion) {
+        return false;
+    }
+
+    const auto& circle = inner.choice.circularRegion;
+    if (!is_valid(circle.center) || !is_valid(outer.center) || circle.radius < 0 || outer.radius < 0) {
+        return false;
+    }
+
+    PositionFix inner_center;
+    inner_center.latitude = convert_latitude(circle.center.latitude);
+    inner_center.longitude = convert_longitude(circle.center.longitude);
+    return distance(inner_center, outer.center) + circle.radius * units::si::meter <= outer.radius * units::si::meter;
+}
+
+bool is_within(const asn1::GeographicRegion& inner, const asn1::SequenceOfRectangularRegion& outer)
+{
+    return inner.present == Vanetza_Security_GeographicRegion_PR_rectangularRegion &&
+        equal(inner.choice.rectangularRegion, outer);
+}
+
+bool is_within(const asn1::GeographicRegion&, const asn1::PolygonalRegion&)
+{
+    return false;
+}
+
+bool is_within(const asn1::GeographicRegion& inner, const asn1::GeographicRegion& outer)
+{
+    switch (outer.present) {
+        case Vanetza_Security_GeographicRegion_PR_circularRegion:
+            return is_within(inner, outer.choice.circularRegion);
+        case Vanetza_Security_GeographicRegion_PR_rectangularRegion:
+            return is_within(inner, outer.choice.rectangularRegion);
+        case Vanetza_Security_GeographicRegion_PR_polygonalRegion:
+            return is_within(inner, outer.choice.polygonalRegion);
+        case Vanetza_Security_GeographicRegion_PR_NOTHING:
+            return true;
+        default:
+            return false;
+    }
+}
 
 bool copy_curve_point(PublicKey& to, const asn1::EccP256CurvePoint& from)
 {

--- a/vanetza/security/v3/certificate.cpp
+++ b/vanetza/security/v3/certificate.cpp
@@ -169,8 +169,10 @@ bool CertificateView::is_allowed_to_issue(ItsAid aid) const
             const auto& subject_permissions = group->subjectPermissions;
             if (subject_permissions.present == Vanetza_Security_SubjectPermissions_PR_all) {
                 return true;
-            } else if (subject_permissions.present == Vanetza_Security_SubjectPermissions_PR_explicit) {
-                return contains_permission(subject_permissions.choice.Explicit, aid);
+            } else if (
+                    subject_permissions.present == Vanetza_Security_SubjectPermissions_PR_explicit &&
+                    contains_permission(subject_permissions.choice.Explicit, aid)) {
+                return true;
             }
         }
     }

--- a/vanetza/security/v3/certificate.cpp
+++ b/vanetza/security/v3/certificate.cpp
@@ -277,6 +277,11 @@ ByteBuffer CertificateView::encode() const
     return m_cert ? asn1::encode_oer(asn_DEF_Vanetza_Security_EtsiTs103097Certificate, m_cert) : ByteBuffer {};
 }
 
+const asn1::EtsiTs103097Certificate* CertificateView::raw_certificate() const
+{
+    return m_cert;
+}
+
 ByteBuffer Certificate::encode() const
 {
     return Wrapper::encode();
@@ -523,6 +528,36 @@ std::list<ItsAid> get_aids(const asn1::EtsiTs103097Certificate& cert)
     if (seq) {
         for (int i = 0; i < seq->list.count; ++i) {
             aids.push_back(seq->list.array[i]->psid);
+        }
+    }
+    return aids;
+}
+
+std::list<ItsAid> get_issuer_aids(const asn1::EtsiTs103097Certificate& cert)
+{
+    std::list<ItsAid> aids;
+    const asn1::SequenceOfPsidGroupPermissions* seq = cert.toBeSigned.certIssuePermissions;
+    if (seq) {
+        for (int i = 0; i < seq->list.count; ++i) {
+            const auto* group = seq->list.array[i];
+            if (!group) {
+                continue;
+            }
+            switch (group->subjectPermissions.present) {
+                case Vanetza_Security_SubjectPermissions_PR_explicit: {
+                    const auto& explicit_perms = group->subjectPermissions.choice.Explicit;
+                    for (int j = 0; j < explicit_perms.list.count; ++j) {
+                        if (explicit_perms.list.array[j]) {
+                            aids.push_back(explicit_perms.list.array[j]->psid);
+                        }
+                    }
+                    break;
+                }
+                case Vanetza_Security_SubjectPermissions_PR_all:
+                    return {};
+                default:
+                    break;
+            }
         }
     }
     return aids;

--- a/vanetza/security/v3/certificate.cpp
+++ b/vanetza/security/v3/certificate.cpp
@@ -159,7 +159,7 @@ bool CertificateView::is_allowed_to_issue(ItsAid aid) const
         return false;
     }
 
-    if (const auto* seq = m_cert->toBeSigned.certIssuePermissions; seq) {
+    if (const auto* seq = m_cert->toBeSigned.certIssuePermissions) {
         for (int i = 0; i < seq->list.count; ++i) {
             const auto* group = seq->list.array[i];
             if (!group) {
@@ -169,10 +169,8 @@ bool CertificateView::is_allowed_to_issue(ItsAid aid) const
             const auto& subject_permissions = group->subjectPermissions;
             if (subject_permissions.present == Vanetza_Security_SubjectPermissions_PR_all) {
                 return true;
-            } else if (
-                    subject_permissions.present == Vanetza_Security_SubjectPermissions_PR_explicit &&
-                    contains_permission(subject_permissions.choice.Explicit, aid)) {
-                return true;
+            } else if (subject_permissions.present == Vanetza_Security_SubjectPermissions_PR_explicit) {
+                return contains_permission(subject_permissions.choice.Explicit, aid);
             }
         }
     }
@@ -182,7 +180,7 @@ bool CertificateView::is_allowed_to_issue(ItsAid aid) const
 
 boost::optional<std::uint8_t> CertificateView::assurance_level() const
 {
-    if (!m_cert || !m_cert->toBeSigned.assuranceLevel || m_cert->toBeSigned.assuranceLevel->size == 0) {
+    if (!m_cert || !m_cert->toBeSigned.assuranceLevel || m_cert->toBeSigned.assuranceLevel->size < 1) {
         return boost::none;
     }
 

--- a/vanetza/security/v3/certificate.hpp
+++ b/vanetza/security/v3/certificate.hpp
@@ -13,6 +13,7 @@
 #include <vanetza/security/v3/location_checker.hpp>
 #include <vanetza/security/v3/validity_restriction.hpp>
 #include <boost/optional/optional_fwd.hpp>
+#include <cstdint>
 #include <list>
 
 namespace vanetza
@@ -109,6 +110,33 @@ public:
     bool valid_for_application(ItsAid aid) const;
 
     /**
+     * Check if certificate issue permissions allow issuing a given application.
+     *
+     * \param aid application to be checked
+     * \return true if certificate may issue certificates for application
+     */
+    bool is_allowed_to_issue(ItsAid aid) const;
+
+    /**
+     * Get subject assurance level encoded in this certificate.
+     *
+     * \return raw assurance level byte if present
+     */
+    boost::optional<std::uint8_t> assurance_level() const;
+
+    /**
+     * Check if this certificate's region restriction is within issuer's region restriction.
+     *
+     * If issuer has no region restriction, any subject region is accepted.
+     * Currently supports circular regions and exact rectangular-region equality;
+     * unsupported region combinations are rejected conservatively.
+     *
+     * \param issuer issuing certificate
+     * \return true if this certificate's region is contained in issuer's region
+     */
+    bool region_is_within(const CertificateView& issuer) const;
+
+    /**
      * Check if certificate has a canonical format
      * \return true if certificate is in canonical format
      */
@@ -125,8 +153,6 @@ public:
      * \return encoded certificate
      */
     ByteBuffer encode() const;
-
-    const asn1::EtsiTs103097Certificate* raw_certificate() const;
 
 protected:
     const asn1::EtsiTs103097Certificate* m_cert = nullptr;
@@ -239,13 +265,6 @@ boost::optional<Signature> get_signature(const asn1::EtsiTs103097Certificate& ce
  * \return list of ITS AIDs
  */
 std::list<ItsAid> get_aids(const asn1::EtsiTs103097Certificate& cert);
-
-/**
- * Get list of ITS AID permissions a certificate is allowed to issue
- * \param cert certificate
- * \return list of ITS AIDs or empty list if all permissions are granted
- */
-std::list<ItsAid> get_issuer_aids(const asn1::EtsiTs103097Certificate& cert);
 
 /**
  * Get application permissions (SSP = service specific permissions)

--- a/vanetza/security/v3/certificate.hpp
+++ b/vanetza/security/v3/certificate.hpp
@@ -126,6 +126,8 @@ public:
      */
     ByteBuffer encode() const;
 
+    const asn1::EtsiTs103097Certificate* raw_certificate() const;
+
 protected:
     const asn1::EtsiTs103097Certificate* m_cert = nullptr;
 };
@@ -237,6 +239,13 @@ boost::optional<Signature> get_signature(const asn1::EtsiTs103097Certificate& ce
  * \return list of ITS AIDs
  */
 std::list<ItsAid> get_aids(const asn1::EtsiTs103097Certificate& cert);
+
+/**
+ * Get list of ITS AID permissions a certificate is allowed to issue
+ * \param cert certificate
+ * \return list of ITS AIDs or empty list if all permissions are granted
+ */
+std::list<ItsAid> get_issuer_aids(const asn1::EtsiTs103097Certificate& cert);
 
 /**
  * Get application permissions (SSP = service specific permissions)

--- a/vanetza/security/v3/certificate_validator.cpp
+++ b/vanetza/security/v3/certificate_validator.cpp
@@ -3,12 +3,9 @@
 #include <vanetza/common/runtime.hpp>
 #include <vanetza/security/v3/certificate.hpp>
 #include <vanetza/security/v3/certificate_validator.hpp>
-#include <vanetza/security/v3/distance.hpp>
-#include <vanetza/security/v3/geometry.hpp>
 #include <vanetza/security/v3/issuer_lookup.hpp>
 #include <vanetza/security/v3/revocation_lookup.hpp>
 #include <vanetza/security/v3/trust_store.hpp>
-#include <algorithm>
 #include <cstdint>
 
 
@@ -32,45 +29,27 @@ bool check_time_consistency(const CertificateView& subject, const CertificateVie
 
 bool check_permission_consistency(const CertificateView& subject, const CertificateView& issuer, ItsAid its_aid)
 {
-    const auto* subject_cert = subject.raw_certificate();
-    const auto* issuer_cert = issuer.raw_certificate();
-    if (!subject_cert || !issuer_cert) {
+    if (subject.is_ca_certificate() && !subject.is_allowed_to_issue(its_aid)) {
+        return false;
+    } else if (subject.is_at_certificate() && !subject.valid_for_application(its_aid)) {
         return false;
     }
 
-    const auto subject_aids = subject.is_ca_certificate() ? get_issuer_aids(*subject_cert) : get_aids(*subject_cert);
-    if (subject_aids.empty() && subject_cert->toBeSigned.certIssuePermissions) {
-        // "all" permissions.
-    } else if (std::find(subject_aids.begin(), subject_aids.end(), its_aid) == subject_aids.end()) {
-        return false;
-    }
-
-    const auto issuer_aids = get_issuer_aids(*issuer_cert);
-    if (issuer_aids.empty() && issuer_cert->toBeSigned.certIssuePermissions) {
-        return true;
-    }
-
-    return std::find(issuer_aids.begin(), issuer_aids.end(), its_aid) != issuer_aids.end();
+    return issuer.is_allowed_to_issue(its_aid);
 }
 
 bool check_assurance_consistency(const CertificateView& subject, const CertificateView& issuer)
 {
-    const auto* subject_cert = subject.raw_certificate();
-    const auto* issuer_cert = issuer.raw_certificate();
-    if (!subject_cert || !issuer_cert) {
-        return false;
-    }
-
-    const auto* subject_assurance = subject_cert->toBeSigned.assuranceLevel;
-    const auto* issuer_assurance = issuer_cert->toBeSigned.assuranceLevel;
+    const auto subject_assurance = subject.assurance_level();
+    const auto issuer_assurance = issuer.assurance_level();
     if (!subject_assurance) {
         return true;
-    } else if (!issuer_assurance || subject_assurance->size == 0 || issuer_assurance->size == 0) {
+    } else if (!issuer_assurance) {
         return false;
     }
 
-    const std::uint8_t subject_value = subject_assurance->buf[0];
-    const std::uint8_t issuer_value = issuer_assurance->buf[0];
+    const auto subject_value = *subject_assurance;
+    const auto issuer_value = *issuer_assurance;
     const std::uint8_t subject_level = (subject_value >> 5) & 0x07;
     const std::uint8_t issuer_level = (issuer_value >> 5) & 0x07;
     const std::uint8_t subject_confidence = (subject_value >> 2) & 0x07;
@@ -80,92 +59,9 @@ bool check_assurance_consistency(const CertificateView& subject, const Certifica
         (subject_level == issuer_level && subject_confidence <= issuer_confidence);
 }
 
-bool equal(const asn1::TwoDLocation& lhs, const asn1::TwoDLocation& rhs)
-{
-    return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude;
-}
-
-bool equal(const asn1::RectangularRegion& lhs, const asn1::RectangularRegion& rhs)
-{
-    return equal(lhs.northWest, rhs.northWest) && equal(lhs.southEast, rhs.southEast);
-}
-
-bool equal(const asn1::SequenceOfRectangularRegion& lhs, const asn1::SequenceOfRectangularRegion& rhs)
-{
-    if (lhs.list.count != rhs.list.count) {
-        return false;
-    }
-
-    for (int i = 0; i < lhs.list.count; ++i) {
-        if (!lhs.list.array[i] || !rhs.list.array[i] || !equal(*lhs.list.array[i], *rhs.list.array[i])) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-bool is_within(const asn1::GeographicRegion& inner, const asn1::CircularRegion& outer)
-{
-    if (inner.present != Vanetza_Security_GeographicRegion_PR_circularRegion) {
-        return false;
-    }
-
-    const auto& circle = inner.choice.circularRegion;
-    if (!is_valid(circle.center) || !is_valid(outer.center) || circle.radius < 0 || outer.radius < 0) {
-        return false;
-    }
-
-    PositionFix inner_center;
-    inner_center.latitude = convert_latitude(circle.center.latitude);
-    inner_center.longitude = convert_longitude(circle.center.longitude);
-    return distance(inner_center, outer.center) + circle.radius * units::si::meter <= outer.radius * units::si::meter;
-}
-
-bool is_within(const asn1::GeographicRegion& inner, const asn1::SequenceOfRectangularRegion& outer)
-{
-    return inner.present == Vanetza_Security_GeographicRegion_PR_rectangularRegion &&
-        equal(inner.choice.rectangularRegion, outer);
-}
-
-bool is_within(const asn1::GeographicRegion&, const asn1::PolygonalRegion&)
-{
-    return false;
-}
-
-bool is_within(const asn1::GeographicRegion& inner, const asn1::GeographicRegion& outer)
-{
-    switch (outer.present) {
-        case Vanetza_Security_GeographicRegion_PR_circularRegion:
-            return is_within(inner, outer.choice.circularRegion);
-        case Vanetza_Security_GeographicRegion_PR_rectangularRegion:
-            return is_within(inner, outer.choice.rectangularRegion);
-        case Vanetza_Security_GeographicRegion_PR_polygonalRegion:
-            return is_within(inner, outer.choice.polygonalRegion);
-        case Vanetza_Security_GeographicRegion_PR_NOTHING:
-            return true;
-        default:
-            return false;
-    }
-}
-
 bool check_region_consistency(const CertificateView& subject, const CertificateView& issuer)
 {
-    const auto* subject_cert = subject.raw_certificate();
-    const auto* issuer_cert = issuer.raw_certificate();
-    if (!subject_cert || !issuer_cert) {
-        return false;
-    }
-
-    const auto* issuer_region = issuer_cert->toBeSigned.region;
-    const auto* subject_region = subject_cert->toBeSigned.region;
-    if (!issuer_region) {
-        return true;
-    } else if (!subject_region) {
-        return false;
-    } else {
-        return is_within(*subject_region, *issuer_region);
-    }
+    return subject.region_is_within(issuer);
 }
 
 } // namespace

--- a/vanetza/security/v3/certificate_validator.cpp
+++ b/vanetza/security/v3/certificate_validator.cpp
@@ -79,7 +79,7 @@ auto DefaultCertificateValidator::valid_for_signing(const CertificateView& signi
     } else if (!is_chain_anchored(signing_cert)) {
         return Verdict::Untrusted;
     } else if (!chain_is_consistent(signing_cert, its_aid)) {
-        return Verdict::Unknown;
+        return Verdict::InconsistentChain;
     } else if (chain_is_revoked(signing_cert)) {
         return Verdict::Revoked;
     } else {

--- a/vanetza/security/v3/certificate_validator.cpp
+++ b/vanetza/security/v3/certificate_validator.cpp
@@ -143,6 +143,16 @@ void DefaultCertificateValidator::disable_location_checks(bool flag)
     m_disable_location_checks = flag;
 }
 
+void DefaultCertificateValidator::disable_chain_consistency_checks(bool flag)
+{
+    m_disable_chain_consistency_checks = flag;
+}
+
+void DefaultCertificateValidator::disable_region_consistency_checks(bool flag)
+{
+    m_disable_region_consistency_checks = flag;
+}
+
 const Certificate* DefaultCertificateValidator::find_issuer_certificate(const CertificateView& at_cert) const
 {
     if (m_issuer_lookup) {
@@ -185,6 +195,10 @@ bool DefaultCertificateValidator::is_chain_anchored(const CertificateView& signi
 
 bool DefaultCertificateValidator::chain_is_consistent(const CertificateView& signing_cert, ItsAid its_aid) const
 {
+    if (m_disable_chain_consistency_checks) {
+        return true;
+    }
+
     if (!m_issuer_lookup) {
         return true;
     }
@@ -239,7 +253,7 @@ bool DefaultCertificateValidator::check_consistency(
     return check_time_consistency(subject, issuer) &&
         check_permission_consistency(subject, issuer, its_aid) &&
         check_assurance_consistency(subject, issuer) &&
-        check_region_consistency(subject, issuer);
+        (m_disable_region_consistency_checks || check_region_consistency(subject, issuer));
 }
 
 } // namespace v3

--- a/vanetza/security/v3/certificate_validator.cpp
+++ b/vanetza/security/v3/certificate_validator.cpp
@@ -1,10 +1,15 @@
 #include <vanetza/common/position_provider.hpp>
+#include <vanetza/common/position_fix.hpp>
 #include <vanetza/common/runtime.hpp>
 #include <vanetza/security/v3/certificate.hpp>
 #include <vanetza/security/v3/certificate_validator.hpp>
+#include <vanetza/security/v3/distance.hpp>
+#include <vanetza/security/v3/geometry.hpp>
 #include <vanetza/security/v3/issuer_lookup.hpp>
 #include <vanetza/security/v3/revocation_lookup.hpp>
 #include <vanetza/security/v3/trust_store.hpp>
+#include <algorithm>
+#include <cstdint>
 
 
 namespace vanetza
@@ -13,6 +18,157 @@ namespace security
 {
 namespace v3
 {
+
+namespace
+{
+
+bool check_time_consistency(const CertificateView& subject, const CertificateView& issuer)
+{
+    const auto subject_time = subject.get_start_and_end_validity();
+    const auto issuer_time = issuer.get_start_and_end_validity();
+    return issuer_time.start_validity <= subject_time.start_validity &&
+        issuer_time.end_validity >= subject_time.end_validity;
+}
+
+bool check_permission_consistency(const CertificateView& subject, const CertificateView& issuer, ItsAid its_aid)
+{
+    const auto* subject_cert = subject.raw_certificate();
+    const auto* issuer_cert = issuer.raw_certificate();
+    if (!subject_cert || !issuer_cert) {
+        return false;
+    }
+
+    const auto subject_aids = subject.is_ca_certificate() ? get_issuer_aids(*subject_cert) : get_aids(*subject_cert);
+    if (subject_aids.empty() && subject_cert->toBeSigned.certIssuePermissions) {
+        // "all" permissions.
+    } else if (std::find(subject_aids.begin(), subject_aids.end(), its_aid) == subject_aids.end()) {
+        return false;
+    }
+
+    const auto issuer_aids = get_issuer_aids(*issuer_cert);
+    if (issuer_aids.empty() && issuer_cert->toBeSigned.certIssuePermissions) {
+        return true;
+    }
+
+    return std::find(issuer_aids.begin(), issuer_aids.end(), its_aid) != issuer_aids.end();
+}
+
+bool check_assurance_consistency(const CertificateView& subject, const CertificateView& issuer)
+{
+    const auto* subject_cert = subject.raw_certificate();
+    const auto* issuer_cert = issuer.raw_certificate();
+    if (!subject_cert || !issuer_cert) {
+        return false;
+    }
+
+    const auto* subject_assurance = subject_cert->toBeSigned.assuranceLevel;
+    const auto* issuer_assurance = issuer_cert->toBeSigned.assuranceLevel;
+    if (!subject_assurance) {
+        return true;
+    } else if (!issuer_assurance || subject_assurance->size == 0 || issuer_assurance->size == 0) {
+        return false;
+    }
+
+    const std::uint8_t subject_value = subject_assurance->buf[0];
+    const std::uint8_t issuer_value = issuer_assurance->buf[0];
+    const std::uint8_t subject_level = (subject_value >> 5) & 0x07;
+    const std::uint8_t issuer_level = (issuer_value >> 5) & 0x07;
+    const std::uint8_t subject_confidence = (subject_value >> 2) & 0x07;
+    const std::uint8_t issuer_confidence = (issuer_value >> 2) & 0x07;
+
+    return subject_level < issuer_level ||
+        (subject_level == issuer_level && subject_confidence <= issuer_confidence);
+}
+
+bool equal(const asn1::TwoDLocation& lhs, const asn1::TwoDLocation& rhs)
+{
+    return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude;
+}
+
+bool equal(const asn1::RectangularRegion& lhs, const asn1::RectangularRegion& rhs)
+{
+    return equal(lhs.northWest, rhs.northWest) && equal(lhs.southEast, rhs.southEast);
+}
+
+bool equal(const asn1::SequenceOfRectangularRegion& lhs, const asn1::SequenceOfRectangularRegion& rhs)
+{
+    if (lhs.list.count != rhs.list.count) {
+        return false;
+    }
+
+    for (int i = 0; i < lhs.list.count; ++i) {
+        if (!lhs.list.array[i] || !rhs.list.array[i] || !equal(*lhs.list.array[i], *rhs.list.array[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool is_within(const asn1::GeographicRegion& inner, const asn1::CircularRegion& outer)
+{
+    if (inner.present != Vanetza_Security_GeographicRegion_PR_circularRegion) {
+        return false;
+    }
+
+    const auto& circle = inner.choice.circularRegion;
+    if (!is_valid(circle.center) || !is_valid(outer.center) || circle.radius < 0 || outer.radius < 0) {
+        return false;
+    }
+
+    PositionFix inner_center;
+    inner_center.latitude = convert_latitude(circle.center.latitude);
+    inner_center.longitude = convert_longitude(circle.center.longitude);
+    return distance(inner_center, outer.center) + circle.radius * units::si::meter <= outer.radius * units::si::meter;
+}
+
+bool is_within(const asn1::GeographicRegion& inner, const asn1::SequenceOfRectangularRegion& outer)
+{
+    return inner.present == Vanetza_Security_GeographicRegion_PR_rectangularRegion &&
+        equal(inner.choice.rectangularRegion, outer);
+}
+
+bool is_within(const asn1::GeographicRegion&, const asn1::PolygonalRegion&)
+{
+    return false;
+}
+
+bool is_within(const asn1::GeographicRegion& inner, const asn1::GeographicRegion& outer)
+{
+    switch (outer.present) {
+        case Vanetza_Security_GeographicRegion_PR_circularRegion:
+            return is_within(inner, outer.choice.circularRegion);
+        case Vanetza_Security_GeographicRegion_PR_rectangularRegion:
+            return is_within(inner, outer.choice.rectangularRegion);
+        case Vanetza_Security_GeographicRegion_PR_polygonalRegion:
+            return is_within(inner, outer.choice.polygonalRegion);
+        case Vanetza_Security_GeographicRegion_PR_NOTHING:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool check_region_consistency(const CertificateView& subject, const CertificateView& issuer)
+{
+    const auto* subject_cert = subject.raw_certificate();
+    const auto* issuer_cert = issuer.raw_certificate();
+    if (!subject_cert || !issuer_cert) {
+        return false;
+    }
+
+    const auto* issuer_region = issuer_cert->toBeSigned.region;
+    const auto* subject_region = subject_cert->toBeSigned.region;
+    if (!issuer_region) {
+        return true;
+    } else if (!subject_region) {
+        return false;
+    } else {
+        return is_within(*subject_region, *issuer_region);
+    }
+}
+
+} // namespace
 
 auto DefaultCertificateValidator::valid_for_signing(const CertificateView& signing_cert, ItsAid its_aid) -> Verdict
 {
@@ -26,6 +182,8 @@ auto DefaultCertificateValidator::valid_for_signing(const CertificateView& signi
         return Verdict::Expired;
     } else if (!is_chain_anchored(signing_cert)) {
         return Verdict::Untrusted;
+    } else if (!chain_is_consistent(signing_cert, its_aid)) {
+        return Verdict::Unknown;
     } else if (chain_is_revoked(signing_cert)) {
         return Verdict::Revoked;
     } else {
@@ -129,6 +287,28 @@ bool DefaultCertificateValidator::is_chain_anchored(const CertificateView& signi
     return false;
 }
 
+bool DefaultCertificateValidator::chain_is_consistent(const CertificateView& signing_cert, ItsAid its_aid) const
+{
+    if (!m_issuer_lookup) {
+        return true;
+    }
+
+    constexpr int max_chain_depth = 8;
+    const CertificateView* subject = &signing_cert;
+    for (int depth = 0; depth < max_chain_depth && !subject->issuer_is_self(); ++depth) {
+        const Certificate* issuer = find_issuer_certificate(*subject);
+        if (!issuer) {
+            return true;
+        }
+        if (!check_consistency(*subject, *issuer, its_aid)) {
+            return false;
+        }
+        subject = issuer;
+    }
+
+    return true;
+}
+
 bool DefaultCertificateValidator::chain_is_revoked(const CertificateView& signing_cert) const
 {
     if (!m_revocation_lookup || !m_issuer_lookup) {
@@ -155,6 +335,15 @@ bool DefaultCertificateValidator::chain_is_revoked(const CertificateView& signin
         cert = issuer;
     }
     return false;
+}
+
+bool DefaultCertificateValidator::check_consistency(
+    const CertificateView& subject, const CertificateView& issuer, ItsAid its_aid) const
+{
+    return check_time_consistency(subject, issuer) &&
+        check_permission_consistency(subject, issuer, its_aid) &&
+        check_assurance_consistency(subject, issuer) &&
+        check_region_consistency(subject, issuer);
 }
 
 } // namespace v3

--- a/vanetza/security/v3/certificate_validator.hpp
+++ b/vanetza/security/v3/certificate_validator.hpp
@@ -63,7 +63,9 @@ public:
 
 private:
     const Certificate* find_issuer_certificate(const CertificateView& certificate) const;
+    bool chain_is_consistent(const CertificateView& signing_cert, ItsAid its_aid) const;
     bool chain_is_revoked(const CertificateView& signing_cert) const;
+    bool check_consistency(const CertificateView& subject, const CertificateView& issuer, ItsAid its_aid) const;
     bool is_chain_anchored(const CertificateView& signing_cert) const;
 
     const Runtime* m_runtime = nullptr;

--- a/vanetza/security/v3/certificate_validator.hpp
+++ b/vanetza/security/v3/certificate_validator.hpp
@@ -31,6 +31,7 @@ public:
         Expired,
         Revoked,
         Untrusted,
+        InconsistentChain,
         OutsideRegion,
         InsufficientPermission,
         Misconfiguration,

--- a/vanetza/security/v3/certificate_validator.hpp
+++ b/vanetza/security/v3/certificate_validator.hpp
@@ -60,6 +60,8 @@ public:
 
     void disable_time_checks(bool flag);
     void disable_location_checks(bool flag);
+    void disable_chain_consistency_checks(bool flag);
+    void disable_region_consistency_checks(bool flag);
 
 private:
     const Certificate* find_issuer_certificate(const CertificateView& certificate) const;
@@ -76,6 +78,8 @@ private:
     const TrustStore* m_trust_store = nullptr;
     bool m_disable_time_checks = false;
     bool m_disable_location_checks = false;
+    bool m_disable_chain_consistency_checks = false;
+    bool m_disable_region_consistency_checks = false;
 };
 
 class NullCertificateValidator : public CertificateValidator

--- a/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
+++ b/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
@@ -10,6 +10,7 @@
 #include <vanetza/security/v3/revocation_lookup.hpp>
 #include <vanetza/security/v3/trust_store.hpp>
 #include <gtest/gtest.h>
+#include <vanetza/asn1/support/OCTET_STRING.h>
 #include <cstring>
 
 using namespace vanetza;
@@ -205,6 +206,16 @@ std::vector<uint8_t> make_germany_data()
     append_u32le(data, static_cast<uint32_t>(wkb.size()));
     data.insert(data.end(), wkb.begin(), wkb.end());
     return data;
+}
+
+void set_issuer_digest(Certificate& cert, const HashedId8& digest)
+{
+    cert->issuer.present = Vanetza_Security_IssuerIdentifier_PR_sha256AndDigest;
+    OCTET_STRING_fromBuf(
+        &cert->issuer.choice.sha256AndDigest,
+        reinterpret_cast<const char*>(digest.data()),
+        digest.size()
+    );
 }
 
 } // anonymous namespace
@@ -449,3 +460,66 @@ TEST_F(DefaultCertificateValidatorTest, untrusted_reported_before_revocation)
               cert_validator.valid_for_signing(cert, vanetza::aid::CA));
 }
 
+TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_validity_outside_issuer_validity)
+{
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    cert->toBeSigned.validityPeriod.start = v2::convert_time32(runtime.now() - std::chrono::hours(2));
+    cert_validator.disable_location_checks(true);
+
+    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+              cert_validator.valid_for_signing(cert, vanetza::aid::CA));
+}
+
+TEST_F(DefaultCertificateValidatorTest, consistency_rejects_permission_not_issued_by_parent)
+{
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    cert_validator.disable_location_checks(true);
+
+    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+              cert_validator.valid_for_signing(cert, vanetza::aid::IPV6_ROUTING));
+}
+
+TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_assurance_without_issuer_assurance)
+{
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    cert->toBeSigned.assuranceLevel = vanetza::asn1::allocate<Vanetza_Security_SubjectAssurance_t>();
+    const char assurance = 0x20;
+    OCTET_STRING_fromBuf(cert->toBeSigned.assuranceLevel, &assurance, sizeof(assurance));
+    cert_validator.disable_location_checks(true);
+
+    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+              cert_validator.valid_for_signing(cert, vanetza::aid::CA));
+}
+
+TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_region_outside_issuer_region)
+{
+    Certificate aa = cert_provider.aa_certificate();
+    aa->toBeSigned.region = vanetza::asn1::allocate<vanetza::security::v3::asn1::GeographicRegion>();
+    aa->toBeSigned.region->present = Vanetza_Security_GeographicRegion_PR_circularRegion;
+    aa->toBeSigned.region->choice.circularRegion.center.latitude = 490144200;
+    aa->toBeSigned.region->choice.circularRegion.center.longitude = 84044170;
+    aa->toBeSigned.region->choice.circularRegion.radius = 500;
+
+    auto aa_digest = aa.calculate_digest();
+    ASSERT_TRUE(aa_digest);
+
+    IssuerMemoryLookup local_issuer_lookup;
+    ASSERT_TRUE(local_issuer_lookup.insert(aa));
+    cert_validator.use_issuer_lookup(&local_issuer_lookup);
+    cert_validator.disable_location_checks(true);
+
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    set_issuer_digest(cert, *aa_digest);
+    cert->toBeSigned.region = vanetza::asn1::allocate<vanetza::security::v3::asn1::GeographicRegion>();
+    cert->toBeSigned.region->present = Vanetza_Security_GeographicRegion_PR_circularRegion;
+    cert->toBeSigned.region->choice.circularRegion.center.latitude = 490144200;
+    cert->toBeSigned.region->choice.circularRegion.center.longitude = 84044170;
+    cert->toBeSigned.region->choice.circularRegion.radius = 1000;
+
+    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+              cert_validator.valid_for_signing(cert, vanetza::aid::CA));
+
+    cert->toBeSigned.region->choice.circularRegion.radius = 100;
+    EXPECT_EQ(CertificateValidator::Verdict::Valid,
+              cert_validator.valid_for_signing(cert, vanetza::aid::CA));
+}

--- a/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
+++ b/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
@@ -518,6 +518,22 @@ TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_assurance_wi
               cert_validator.valid_for_signing(cert, vanetza::aid::CA));
 }
 
+TEST_F(DefaultCertificateValidatorTest, consistency_can_be_disabled)
+{
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    cert->toBeSigned.assuranceLevel = vanetza::asn1::allocate<Vanetza_Security_SubjectAssurance_t>();
+    const char assurance = 0x20;
+    OCTET_STRING_fromBuf(cert->toBeSigned.assuranceLevel, &assurance, sizeof(assurance));
+    cert_validator.disable_location_checks(true);
+
+    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+              cert_validator.valid_for_signing(cert, vanetza::aid::CA));
+
+    cert_validator.disable_chain_consistency_checks(true);
+    EXPECT_EQ(CertificateValidator::Verdict::Valid,
+              cert_validator.valid_for_signing(cert, vanetza::aid::CA));
+}
+
 TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_region_outside_issuer_region)
 {
     Certificate aa = cert_provider.aa_certificate();
@@ -546,6 +562,11 @@ TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_region_outsi
     EXPECT_EQ(CertificateValidator::Verdict::Unknown,
               cert_validator.valid_for_signing(cert, vanetza::aid::CA));
 
+    cert_validator.disable_region_consistency_checks(true);
+    EXPECT_EQ(CertificateValidator::Verdict::Valid,
+              cert_validator.valid_for_signing(cert, vanetza::aid::CA));
+
+    cert_validator.disable_region_consistency_checks(false);
     cert->toBeSigned.region->choice.circularRegion.radius = 100;
     EXPECT_EQ(CertificateValidator::Verdict::Valid,
               cert_validator.valid_for_signing(cert, vanetza::aid::CA));

--- a/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
+++ b/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
@@ -479,6 +479,33 @@ TEST_F(DefaultCertificateValidatorTest, consistency_rejects_permission_not_issue
               cert_validator.valid_for_signing(cert, vanetza::aid::IPV6_ROUTING));
 }
 
+TEST_F(DefaultCertificateValidatorTest, consistency_accepts_permission_issued_by_parent_with_all_permissions)
+{
+    Certificate aa = cert_provider.aa_certificate();
+    ASSERT_TRUE(aa->toBeSigned.certIssuePermissions);
+    ASSERT_GT(aa->toBeSigned.certIssuePermissions->list.count, 0);
+    ASSERT_TRUE(aa->toBeSigned.certIssuePermissions->list.array[0]);
+
+    auto& subject_permissions = aa->toBeSigned.certIssuePermissions->list.array[0]->subjectPermissions;
+    asn_sequence_empty(&subject_permissions.choice.Explicit);
+    subject_permissions.present = Vanetza_Security_SubjectPermissions_PR_all;
+    subject_permissions.choice.all = 0;
+
+    auto aa_digest = aa.calculate_digest();
+    ASSERT_TRUE(aa_digest);
+
+    IssuerMemoryLookup local_issuer_lookup;
+    ASSERT_TRUE(local_issuer_lookup.insert(aa));
+    cert_validator.use_issuer_lookup(&local_issuer_lookup);
+    cert_validator.disable_location_checks(true);
+
+    Certificate cert = cert_provider.generate_authorization_ticket();
+    set_issuer_digest(cert, *aa_digest);
+
+    EXPECT_EQ(CertificateValidator::Verdict::Valid,
+              cert_validator.valid_for_signing(cert, vanetza::aid::IPV6_ROUTING));
+}
+
 TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_assurance_without_issuer_assurance)
 {
     Certificate cert = cert_provider.generate_authorization_ticket();

--- a/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
+++ b/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
@@ -466,7 +466,7 @@ TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_validity_out
     cert->toBeSigned.validityPeriod.start = v2::convert_time32(runtime.now() - std::chrono::hours(2));
     cert_validator.disable_location_checks(true);
 
-    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+    EXPECT_EQ(CertificateValidator::Verdict::InconsistentChain,
               cert_validator.valid_for_signing(cert, vanetza::aid::CA));
 }
 
@@ -475,7 +475,7 @@ TEST_F(DefaultCertificateValidatorTest, consistency_rejects_permission_not_issue
     Certificate cert = cert_provider.generate_authorization_ticket();
     cert_validator.disable_location_checks(true);
 
-    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+    EXPECT_EQ(CertificateValidator::Verdict::InconsistentChain,
               cert_validator.valid_for_signing(cert, vanetza::aid::IPV6_ROUTING));
 }
 
@@ -514,7 +514,7 @@ TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_assurance_wi
     OCTET_STRING_fromBuf(cert->toBeSigned.assuranceLevel, &assurance, sizeof(assurance));
     cert_validator.disable_location_checks(true);
 
-    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+    EXPECT_EQ(CertificateValidator::Verdict::InconsistentChain,
               cert_validator.valid_for_signing(cert, vanetza::aid::CA));
 }
 
@@ -526,7 +526,7 @@ TEST_F(DefaultCertificateValidatorTest, consistency_can_be_disabled)
     OCTET_STRING_fromBuf(cert->toBeSigned.assuranceLevel, &assurance, sizeof(assurance));
     cert_validator.disable_location_checks(true);
 
-    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+    EXPECT_EQ(CertificateValidator::Verdict::InconsistentChain,
               cert_validator.valid_for_signing(cert, vanetza::aid::CA));
 
     cert_validator.disable_chain_consistency_checks(true);
@@ -559,7 +559,7 @@ TEST_F(DefaultCertificateValidatorTest, consistency_rejects_subject_region_outsi
     cert->toBeSigned.region->choice.circularRegion.center.longitude = 84044170;
     cert->toBeSigned.region->choice.circularRegion.radius = 1000;
 
-    EXPECT_EQ(CertificateValidator::Verdict::Unknown,
+    EXPECT_EQ(CertificateValidator::Verdict::InconsistentChain,
               cert_validator.valid_for_signing(cert, vanetza::aid::CA));
 
     cert_validator.disable_region_consistency_checks(true);


### PR DESCRIPTION
This adds v3 certificate chain consistency checks between a subject certificate and its issuer.

The validator now checks:
- subject validity period is contained in issuer validity period
- requested ITS-AID is permitted by the issuer
- subject assurance does not exceed issuer assurance
- subject geographic region is contained in issuer region where supported

note: the permission consistency check is scoped to the requested ITS-AID, not all permissions in the AT. That is intentional because the current naive AT has IPV6_ROUTING, while the current AA does not issue that permission (we can add it later myabe).