### PR TITLE
Fix memory leak in DefaultCertificateValidatorTest

### DIFF
--- a/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
+++ b/vanetza/security/v3/tests/default_certificate_validator_v3.cpp
@@ -487,7 +487,7 @@ TEST_F(DefaultCertificateValidatorTest, consistency_accepts_permission_issued_by
     ASSERT_TRUE(aa->toBeSigned.certIssuePermissions->list.array[0]);
 
     auto& subject_permissions = aa->toBeSigned.certIssuePermissions->list.array[0]->subjectPermissions;
-    asn_sequence_empty(&subject_permissions.choice.Explicit);
+    vanetza::asn1::reset(asn_DEF_Vanetza_Security_SubjectPermissions, &subject_permissions);
     subject_permissions.present = Vanetza_Security_SubjectPermissions_PR_all;
     subject_permissions.choice.all = 0;
 


### PR DESCRIPTION
There is a memory leak reported in `GTest_DefaultCertificateValidatorV3` when I run the tests with `-fsanitize=address`. Using `vanetza::asn1::reset ` instead of `asn_sequence_empty` fixes the memory leak warning.

It seems this is not a problem in the library itself but it might be better to fix it anyway. Yet, I'm not sure this is the correct way to solve the issue. Please revise it if it isn't so.

```
106: Test command: /home/bsenkus/projects/facilities/build/debug-asan/extern/vanetza/tests/GTest_DefaultCertificateValidatorV3
106: Working Directory: /home/bsenkus/projects/facilities/extern/vanetza/vanetza/security/v3/tests
106: Test timeout computed to be: 10000000
106: Running main() from /home/bsenkus/projects/facilities/extern/vanetza/gtest/googletest-1.16.0/googletest/src/gtest_main.cc
106: [==========] Running 21 tests from 1 test suite.
106: [----------] Global test environment set-up.
106: [----------] 21 tests from DefaultCertificateValidatorTest
106: [ RUN      ] DefaultCertificateValidatorTest.region_validator
106: [       OK ] DefaultCertificateValidatorTest.region_validator (5 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.identified_region_country_only_with_database
106: [       OK ] DefaultCertificateValidatorTest.identified_region_country_only_with_database (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.identified_region_without_database_permissive
106: [       OK ] DefaultCertificateValidatorTest.identified_region_without_database_permissive (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.crl_not_attached_is_valid
106: [       OK ] DefaultCertificateValidatorTest.crl_not_attached_is_valid (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.crl_empty_is_valid
106: [       OK ] DefaultCertificateValidatorTest.crl_empty_is_valid (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.crl_at_revoked_by_aa
106: [       OK ] DefaultCertificateValidatorTest.crl_at_revoked_by_aa (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.crl_aa_revoked_by_root
106: [       OK ] DefaultCertificateValidatorTest.crl_aa_revoked_by_root (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.crl_unrelated_entry_does_not_revoke
106: [       OK ] DefaultCertificateValidatorTest.crl_unrelated_entry_does_not_revoke (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.crl_expiry_reported_before_revocation
106: [       OK ] DefaultCertificateValidatorTest.crl_expiry_reported_before_revocation (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.identified_region_country_and_regions_fallback
106: [       OK ] DefaultCertificateValidatorTest.identified_region_country_and_regions_fallback (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.trust_store_not_attached_is_valid
106: [       OK ] DefaultCertificateValidatorTest.trust_store_not_attached_is_valid (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.anchored_chain_is_valid
106: [       OK ] DefaultCertificateValidatorTest.anchored_chain_is_valid (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.untrusted_when_root_not_in_trust_store
106: [       OK ] DefaultCertificateValidatorTest.untrusted_when_root_not_in_trust_store (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.untrusted_when_chain_breaks
106: [       OK ] DefaultCertificateValidatorTest.untrusted_when_chain_breaks (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.untrusted_reported_before_revocation
106: [       OK ] DefaultCertificateValidatorTest.untrusted_reported_before_revocation (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.consistency_rejects_subject_validity_outside_issuer_validity
106: [       OK ] DefaultCertificateValidatorTest.consistency_rejects_subject_validity_outside_issuer_validity (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.consistency_rejects_permission_not_issued_by_parent
106: [       OK ] DefaultCertificateValidatorTest.consistency_rejects_permission_not_issued_by_parent (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.consistency_accepts_permission_issued_by_parent_with_all_permissions
106: [       OK ] DefaultCertificateValidatorTest.consistency_accepts_permission_issued_by_parent_with_all_permissions (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.consistency_rejects_subject_assurance_without_issuer_assurance
106: [       OK ] DefaultCertificateValidatorTest.consistency_rejects_subject_assurance_without_issuer_assurance (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.consistency_can_be_disabled
106: [       OK ] DefaultCertificateValidatorTest.consistency_can_be_disabled (0 ms)
106: [ RUN      ] DefaultCertificateValidatorTest.consistency_rejects_subject_region_outside_issuer_region
106: [       OK ] DefaultCertificateValidatorTest.consistency_rejects_subject_region_outside_issuer_region (0 ms)
106: [----------] 21 tests from DefaultCertificateValidatorTest (13 ms total)
106: 
106: [----------] Global test environment tear-down
106: [==========] 21 tests from 1 test suite ran. (13 ms total)
106: [  PASSED  ] 21 tests.
106: 
106: =================================================================
106: ==99041==ERROR: LeakSanitizer: detected memory leaks
106: 
106: Direct leak of 280 byte(s) in 7 object(s) allocated from:
106:     #0 0x7f48070ef24f in calloc (/lib64/libasan.so.8+0xef24f) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
106:     #1 0x00000052d3e3 in SEQUENCE_decode_oer /home/bsenkus/projects/facilities/extern/vanetza/vanetza/asn1/support/constr_SEQUENCE_oer.c:105
106: 
106: Indirect leak of 952 byte(s) in 7 object(s) allocated from:
106:     #0 0x7f48070ef24f in calloc (/lib64/libasan.so.8+0xef24f) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
106:     #1 0x00000051f711 in CHOICE_decode_oer /home/bsenkus/projects/facilities/extern/vanetza/vanetza/asn1/support/constr_CHOICE_oer.c:152
106: 
106: Indirect leak of 693 byte(s) in 14 object(s) allocated from:
106:     #0 0x7f48070ef24f in calloc (/lib64/libasan.so.8+0xef24f) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
106:     #1 0x0000005155e1 in asn_bit_data_new_contiguous /home/bsenkus/projects/facilities/extern/vanetza/vanetza/asn1/support/asn_bit_data.c:21
106: 
106: Indirect leak of 58 byte(s) in 14 object(s) allocated from:
106:     #0 0x7f48070ef41f in malloc (/lib64/libasan.so.8+0xef41f) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
106:     #1 0x00000050e96b in OCTET_STRING_decode_oer /home/bsenkus/projects/facilities/extern/vanetza/vanetza/asn1/support/OCTET_STRING_oer.c:80
106: 
106: SUMMARY: AddressSanitizer: 1983 byte(s) leaked in 42 allocation(s).
Failed
```

@Abderraouf-D @riebl