### PR TITLE
security: add C++17 requirement

### DIFF
--- a/vanetza/security/CMakeLists.txt
+++ b/vanetza/security/CMakeLists.txt
@@ -71,6 +71,7 @@ add_vanetza_component(security
 )
 target_link_libraries(security PUBLIC Boost::headers asn1 asn1_security common net)
 target_link_libraries(security PRIVATE geodesy)
+target_compile_features(security PUBLIC cxx_std_17)
 
 if(VANETZA_WITH_CRYPTOPP)
     set_property(TARGET security APPEND PROPERTY


### PR DESCRIPTION
Build was not working for me because of C++17 `insert_or_assign` construct.